### PR TITLE
feat: Optimize performance to match a baseline graphql.js target

### DIFF
--- a/.changeset/stupid-clouds-switch.md
+++ b/.changeset/stupid-clouds-switch.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Optimize performance of `print` and `parse` with minor adjustments.

--- a/src/error.ts
+++ b/src/error.ts
@@ -38,7 +38,7 @@ export class GraphQLError extends Error {
       }
     }
 
-    this.extensions = extensions || {};
+    this.extensions = _extensions || {};
   }
 
   toJSON(): any {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -52,16 +52,15 @@ function ignored() {
   for (
     let char = input.charCodeAt(idx++) | 0;
     char === 9 /*'\t'*/ ||
-      char === 10 /*'\n'*/ ||
-      char === 13 /*'\r'*/ ||
-      char === 32 /*' '*/ ||
-      char === 35 /*'#'*/ ||
-      char === 44 /*','*/ ||
-      char === 65279 /*'\ufeff'*/;
+    char === 10 /*'\n'*/ ||
+    char === 13 /*'\r'*/ ||
+    char === 32 /*' '*/ ||
+    char === 35 /*'#'*/ ||
+    char === 44 /*','*/ ||
+    char === 65279 /*'\ufeff'*/;
     char = input.charCodeAt(idx++) | 0
   ) {
-    if (char === 35 /*'#'*/)
-      while ((char = input.charCodeAt(idx++)) !== 10 && char !== 13);
+    if (char === 35 /*'#'*/) while ((char = input.charCodeAt(idx++)) !== 10 && char !== 13);
   }
   idx--;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -47,11 +47,23 @@ export function blockString(string: string) {
   return out;
 }
 
-const ignoredRe = /(?:[\s,]*|#[^\n\r]*)*/y;
+// Note: This is equivalent to: /(?:[\s,]*|#[^\n\r]*)*/y
 function ignored() {
-  ignoredRe.lastIndex = idx;
-  ignoredRe.test(input);
-  idx = ignoredRe.lastIndex;
+  for (
+    let char = input.charCodeAt(idx++) | 0;
+    char === 9 /*'\t'*/ ||
+      char === 10 /*'\n'*/ ||
+      char === 13 /*'\r'*/ ||
+      char === 32 /*' '*/ ||
+      char === 35 /*'#'*/ ||
+      char === 44 /*','*/ ||
+      char === 65279 /*'\ufeff'*/;
+    char = input.charCodeAt(idx++) | 0
+  ) {
+    if (char === 35 /*'#'*/)
+      while ((char = input.charCodeAt(idx++)) !== 10 && char !== 13);
+  }
+  idx--;
 }
 
 const nameRe = /[_\w][_\d\w]*/y;
@@ -221,7 +233,6 @@ function directives(constant: boolean): ast.DirectiveNode[] {
 }
 
 function field(): ast.FieldNode | undefined {
-  ignored();
   let _name = name();
   if (_name) {
     ignored();
@@ -296,7 +307,6 @@ function typeCondition(): ast.NamedTypeNode | undefined {
 const fragmentSpreadRe = /\.\.\./y;
 
 function fragmentSpread(): ast.FragmentSpreadNode | ast.InlineFragmentNode | undefined {
-  ignored();
   if (advance(fragmentSpreadRe)) {
     ignored();
     const _idx = idx;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -13,114 +13,122 @@ const hasItems = <T>(array: ReadonlyArray<T> | undefined | null): array is Reado
 
 const MAX_LINE_LENGTH = 80;
 
+const nodes: {
+  [NodeT in ASTNode as NodeT['kind']]?: (node: NodeT) => string;
+} = {
+  OperationDefinition(node) {
+    if (
+      node.operation === 'query' &&
+      !node.name &&
+      !hasItems(node.variableDefinitions) &&
+      !hasItems(node.directives)
+    ) {
+      return nodes.SelectionSet!(node.selectionSet);
+    }
+    let out: string = node.operation;
+    if (node.name) out += ' ' + node.name.value;
+    if (hasItems(node.variableDefinitions)) {
+      if (!node.name) out += ' ';
+      out += '(' + node.variableDefinitions.map(nodes.VariableDefinition!).join(', ') + ')';
+    }
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return out + ' ' + nodes.SelectionSet!(node.selectionSet);
+  },
+  VariableDefinition(node) {
+    let out = nodes.Variable!(node.variable) + ': ' + print(node.type);
+    if (node.defaultValue) out += ' = ' + print(node.defaultValue);
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return out;
+  },
+  Field(node) {
+    let out = (node.alias ? node.alias.value + ': ' : '') + node.name.value;
+    if (hasItems(node.arguments)) {
+      const args = node.arguments.map(nodes.Argument!);
+      const argsLine = out + '(' + args.join(', ') + ')';
+      out =
+        argsLine.length > MAX_LINE_LENGTH
+          ? out + '(\n  ' + args.join('\n').replace(/\n/g, '\n  ') + '\n)'
+          : argsLine;
+    }
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return node.selectionSet ? out + ' ' + nodes.SelectionSet!(node.selectionSet) : out;
+  },
+  StringValue(node) {
+    return node.block ? printBlockString(node.value) : printString(node.value);
+  },
+  BooleanValue(node) {
+    return '' + node.value;
+  },
+  NullValue(_node) {
+    return 'null';
+  },
+  IntValue(node) {
+    return node.value;
+  },
+  FloatValue(node) {
+    return node.value;
+  },
+  EnumValue(node) {
+    return node.value;
+  },
+  Name(node) {
+    return node.value;
+  },
+  Variable(node) {
+    return '$' + node.name.value;
+  },
+  ListValue(node) {
+    return '[' + node.values.map(print).join(', ') + ']';
+  },
+  ObjectValue(node) {
+    return '{' + node.fields.map(nodes.ObjectField!).join(', ') + '}';
+  },
+  ObjectField(node) {
+    return node.name.value + ': ' + print(node.value);
+  },
+  Document(node) {
+    return hasItems(node.definitions) ? node.definitions.map(print).join('\n\n') : '';
+  },
+  SelectionSet(node) {
+    return '{\n  ' + node.selections.map(print).join('\n').replace(/\n/g, '\n  ') + '\n}';
+  },
+  Argument(node) {
+    return node.name.value + ': ' + print(node.value);
+  },
+  FragmentSpread(node) {
+    let out = '...' + node.name.value;
+    if (hasItems(node.directives))
+      out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return out;
+  },
+  InlineFragment(node) {
+    let out = '...';
+    if (node.typeCondition) out += ' on ' + node.typeCondition.name.value;
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return out + ' ' + print(node.selectionSet);
+  },
+  FragmentDefinition(node) {
+    let out = 'fragment ' + node.name.value;
+    out += ' on ' + node.typeCondition.name.value;
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    return out + ' ' + print(node.selectionSet);
+  },
+  Directive(node) {
+    let out = '@' + node.name.value;
+    if (hasItems(node.arguments)) out += '(' + node.arguments.map(nodes.Argument!).join(', ') + ')';
+    return out;
+  },
+  NamedType(node) {
+    return node.name.value;
+  },
+  ListType(node) {
+    return '[' + print(node.type) + ']';
+  },
+  NonNullType(node) {
+    return print(node.type) + '!';
+  },
+};
+
 export function print(node: ASTNode): string {
-  let out: string;
-  switch (node.kind) {
-    case 'OperationDefinition':
-      if (
-        node.operation === 'query' &&
-        !node.name &&
-        !hasItems(node.variableDefinitions) &&
-        !hasItems(node.directives)
-      ) {
-        return print(node.selectionSet);
-      }
-      out = node.operation;
-      if (node.name) out += ' ' + node.name.value;
-      if (hasItems(node.variableDefinitions)) {
-        if (!node.name) out += ' ';
-        out += '(' + node.variableDefinitions.map(print).join(', ') + ')';
-      }
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return out + ' ' + print(node.selectionSet);
-
-    case 'VariableDefinition':
-      out = print(node.variable) + ': ' + print(node.type);
-      if (node.defaultValue) out += ' = ' + print(node.defaultValue);
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return out;
-
-    case 'Field':
-      out = (node.alias ? print(node.alias) + ': ' : '') + node.name.value;
-      if (hasItems(node.arguments)) {
-        const args = node.arguments.map(print);
-        const argsLine = out + '(' + args.join(', ') + ')';
-        out =
-          argsLine.length > MAX_LINE_LENGTH
-            ? out + '(\n  ' + args.join('\n').replace(/\n/g, '\n  ') + '\n)'
-            : argsLine;
-      }
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return node.selectionSet ? out + ' ' + print(node.selectionSet) : out;
-
-    case 'StringValue':
-      return node.block ? printBlockString(node.value) : printString(node.value);
-
-    case 'BooleanValue':
-      return '' + node.value;
-
-    case 'NullValue':
-      return 'null';
-
-    case 'IntValue':
-    case 'FloatValue':
-    case 'EnumValue':
-    case 'Name':
-      return node.value;
-
-    case 'ListValue':
-      return '[' + node.values.map(print).join(', ') + ']';
-
-    case 'ObjectValue':
-      return '{' + node.fields.map(print).join(', ') + '}';
-
-    case 'ObjectField':
-      return node.name.value + ': ' + print(node.value);
-
-    case 'Variable':
-      return '$' + node.name.value;
-
-    case 'Document':
-      return hasItems(node.definitions) ? node.definitions.map(print).join('\n\n') : '';
-
-    case 'SelectionSet':
-      return '{\n  ' + node.selections.map(print).join('\n').replace(/\n/g, '\n  ') + '\n}';
-
-    case 'Argument':
-      return node.name.value + ': ' + print(node.value);
-
-    case 'FragmentSpread':
-      out = '...' + node.name.value;
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return out;
-
-    case 'InlineFragment':
-      out = '...';
-      if (node.typeCondition) out += ' on ' + node.typeCondition.name.value;
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return out + ' ' + print(node.selectionSet);
-
-    case 'FragmentDefinition':
-      out = 'fragment ' + node.name.value;
-      out += ' on ' + node.typeCondition.name.value;
-      if (hasItems(node.directives)) out += ' ' + node.directives.map(print).join(' ');
-      return out + ' ' + print(node.selectionSet);
-
-    case 'Directive':
-      out = '@' + node.name.value;
-      if (hasItems(node.arguments)) out += '(' + node.arguments.map(print).join(', ') + ')';
-      return out;
-
-    case 'NamedType':
-      return node.name.value;
-
-    case 'ListType':
-      return '[' + print(node.type) + ']';
-
-    case 'NonNullType':
-      return print(node.type) + '!';
-
-    default:
-      return '';
-  }
+  return nodes[node.kind] ? nodes[node.kind]!(node as any) : '';
 }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -97,8 +97,7 @@ const nodes: {
   },
   FragmentSpread(node) {
     let out = '...' + node.name.value;
-    if (hasItems(node.directives))
-      out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
     return out;
   },
   InlineFragment(node) {


### PR DESCRIPTION
## Summary

This strategically optimizes `parse` and `print`, since we wouldn't want these two to get any slower than `graphql.js`' implementations. We've previously struggled to optimize what was in `graphql-web-lite`, but the new implementations make this a little easier.

## Set of changes

- Optimize hot path for `ignored()` characters
- Remove redundant `ignored()` calls in `field()` and `fragmentSpread()`
- Split up `print()` into separate monomorphic functions