### PR TITLE
feat: Extend local AST types with graphql’s types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/graphql.web",
   "module": "./dist/graphql.web.mjs",
   "types": "./dist/graphql.web.d.ts",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",
@@ -21,7 +22,14 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": false,
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    }
+  },
   "public": true,
   "keywords": [
     "graphql",

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -150,7 +150,17 @@ const dtsConfig = {
   output: {
     dir: './dist',
     entryFileNames: '[name].d.ts',
-    format: 'es'
+    format: 'es',
+    plugins: [
+      {
+        renderChunk(code, chunk) {
+          if (chunk.fileName.endsWith('d.ts')) {
+            const gqlImportRe = /(import\s+(?:[*\s{}\w\d]+)\s*from\s*'graphql';?)/g;
+            return code.replace(gqlImportRe, x => '/*!@ts-ignore*/\n' + x);
+          }
+        },
+      },
+    ],
   },
 };
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -27,7 +27,8 @@ import type {
   InputObjectTypeExtensionNode,
 } from './schemaAst';
 
-export type ASTNode = Or<GraphQL.ASTNode, (
+export type ASTNode = Or<
+  GraphQL.ASTNode,
   | NameNode
   | DocumentNode
   | OperationDefinitionNode
@@ -71,117 +72,152 @@ export type ASTNode = Or<GraphQL.ASTNode, (
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
-)>;
+>;
 
-export type NameNode = Or<GraphQL.NameNode, {
-  readonly kind: Kind.NAME;
-  readonly value: string;
-  readonly loc?: Location;
-}>;
+export type NameNode = Or<
+  GraphQL.NameNode,
+  {
+    readonly kind: Kind.NAME;
+    readonly value: string;
+    readonly loc?: Location;
+  }
+>;
 
-export type DocumentNode = Or<GraphQL.DocumentNode, {
-  readonly kind: Kind.DOCUMENT;
-  readonly definitions: ReadonlyArray<DefinitionNode>;
-  readonly loc?: Location;
-}>;
+export type DocumentNode = Or<
+  GraphQL.DocumentNode,
+  {
+    readonly kind: Kind.DOCUMENT;
+    readonly definitions: ReadonlyArray<DefinitionNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type DefinitionNode = Or<GraphQL.DefinitionNode, (
-  | ExecutableDefinitionNode
-  | TypeSystemDefinitionNode
-  | TypeSystemExtensionNode
-)>;
+export type DefinitionNode = Or<
+  GraphQL.DefinitionNode,
+  ExecutableDefinitionNode | TypeSystemDefinitionNode | TypeSystemExtensionNode
+>;
 
-export type ExecutableDefinitionNode = Or<GraphQL.ExecutableDefinitionNode, (
-  | OperationDefinitionNode
-  | FragmentDefinitionNode
-)>;
+export type ExecutableDefinitionNode = Or<
+  GraphQL.ExecutableDefinitionNode,
+  OperationDefinitionNode | FragmentDefinitionNode
+>;
 
-export type OperationDefinitionNode = Or<GraphQL.OperationDefinitionNode, {
-  readonly kind: Kind.OPERATION_DEFINITION;
-  readonly operation: OperationTypeNode;
-  readonly name?: NameNode;
-  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly selectionSet: SelectionSetNode;
-  readonly loc?: Location;
-}>;
+export type OperationDefinitionNode = Or<
+  GraphQL.OperationDefinitionNode,
+  {
+    readonly kind: Kind.OPERATION_DEFINITION;
+    readonly operation: OperationTypeNode;
+    readonly name?: NameNode;
+    readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+    readonly directives?: ReadonlyArray<DirectiveNode>;
+    readonly selectionSet: SelectionSetNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type VariableDefinitionNode = Or<GraphQL.VariableDefinitionNode, {
-  readonly kind: Kind.VARIABLE_DEFINITION;
-  readonly variable: VariableNode;
-  readonly type: TypeNode;
-  readonly defaultValue?: ConstValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly loc?: Location;
-}>;
+export type VariableDefinitionNode = Or<
+  GraphQL.VariableDefinitionNode,
+  {
+    readonly kind: Kind.VARIABLE_DEFINITION;
+    readonly variable: VariableNode;
+    readonly type: TypeNode;
+    readonly defaultValue?: ConstValueNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type VariableNode = Or<GraphQL.VariableNode, {
-  readonly kind: Kind.VARIABLE;
-  readonly name: NameNode;
-  readonly loc?: Location;
-}>;
+export type VariableNode = Or<
+  GraphQL.VariableNode,
+  {
+    readonly kind: Kind.VARIABLE;
+    readonly name: NameNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type SelectionSetNode = Or<GraphQL.SelectionSetNode, {
-  readonly kind: Kind.SELECTION_SET;
-  readonly selections: ReadonlyArray<SelectionNode>;
-  readonly loc?: Location;
-}>;
+export type SelectionSetNode = Or<
+  GraphQL.SelectionSetNode,
+  {
+    readonly kind: Kind.SELECTION_SET;
+    readonly selections: ReadonlyArray<SelectionNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export declare type SelectionNode = Or<GraphQL.SelectionNode, (
-  | FieldNode
-  | FragmentSpreadNode
-  | InlineFragmentNode
-)>;
+export declare type SelectionNode = Or<
+  GraphQL.SelectionNode,
+  FieldNode | FragmentSpreadNode | InlineFragmentNode
+>;
 
-export type FieldNode = Or<GraphQL.FieldNode, {
-  readonly kind: Kind.FIELD;
-  readonly alias?: NameNode;
-  readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ArgumentNode>;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly selectionSet?: SelectionSetNode;
-  readonly loc?: Location;
-}>;
+export type FieldNode = Or<
+  GraphQL.FieldNode,
+  {
+    readonly kind: Kind.FIELD;
+    readonly alias?: NameNode;
+    readonly name: NameNode;
+    readonly arguments?: ReadonlyArray<ArgumentNode>;
+    readonly directives?: ReadonlyArray<DirectiveNode>;
+    readonly selectionSet?: SelectionSetNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type ArgumentNode = Or<GraphQL.ArgumentNode, {
-  readonly kind: Kind.ARGUMENT;
-  readonly name: NameNode;
-  readonly value: ValueNode;
-  readonly loc?: Location;
-}>;
+export type ArgumentNode = Or<
+  GraphQL.ArgumentNode,
+  {
+    readonly kind: Kind.ARGUMENT;
+    readonly name: NameNode;
+    readonly value: ValueNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type ConstArgumentNode = Or<GraphQL.ConstArgumentNode, {
-  readonly kind: Kind.ARGUMENT;
-  readonly name: NameNode;
-  readonly value: ConstValueNode;
-  readonly loc?: Location;
-}>;
+export type ConstArgumentNode = Or<
+  GraphQL.ConstArgumentNode,
+  {
+    readonly kind: Kind.ARGUMENT;
+    readonly name: NameNode;
+    readonly value: ConstValueNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type FragmentSpreadNode = Or<GraphQL.FragmentSpreadNode, {
-  readonly kind: Kind.FRAGMENT_SPREAD;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly loc?: Location;
-}>;
+export type FragmentSpreadNode = Or<
+  GraphQL.FragmentSpreadNode,
+  {
+    readonly kind: Kind.FRAGMENT_SPREAD;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<DirectiveNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type InlineFragmentNode = Or<GraphQL.InlineFragmentNode, {
-  readonly kind: Kind.INLINE_FRAGMENT;
-  readonly typeCondition?: NamedTypeNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly selectionSet: SelectionSetNode;
-  readonly loc?: Location;
-}>;
+export type InlineFragmentNode = Or<
+  GraphQL.InlineFragmentNode,
+  {
+    readonly kind: Kind.INLINE_FRAGMENT;
+    readonly typeCondition?: NamedTypeNode;
+    readonly directives?: ReadonlyArray<DirectiveNode>;
+    readonly selectionSet: SelectionSetNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type FragmentDefinitionNode = Or<GraphQL.FragmentDefinitionNode, {
-  readonly kind: Kind.FRAGMENT_DEFINITION;
-  readonly name: NameNode;
-  readonly typeCondition: NamedTypeNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly selectionSet: SelectionSetNode;
-  readonly loc?: Location;
-}>;
+export type FragmentDefinitionNode = Or<
+  GraphQL.FragmentDefinitionNode,
+  {
+    readonly kind: Kind.FRAGMENT_DEFINITION;
+    readonly name: NameNode;
+    readonly typeCondition: NamedTypeNode;
+    readonly directives?: ReadonlyArray<DirectiveNode>;
+    readonly selectionSet: SelectionSetNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type ValueNode = Or<GraphQL.ValueNode, (
+export type ValueNode = Or<
+  GraphQL.ValueNode,
   | VariableNode
   | IntValueNode
   | FloatValueNode
@@ -191,9 +227,10 @@ export type ValueNode = Or<GraphQL.ValueNode, (
   | EnumValueNode
   | ListValueNode
   | ObjectValueNode
-)>;
+>;
 
-export type ConstValueNode = Or<GraphQL.ConstValueNode, (
+export type ConstValueNode = Or<
+  GraphQL.ConstValueNode,
   | IntValueNode
   | FloatValueNode
   | StringValueNode
@@ -202,116 +239,163 @@ export type ConstValueNode = Or<GraphQL.ConstValueNode, (
   | EnumValueNode
   | ConstListValueNode
   | ConstObjectValueNode
-)>;
+>;
 
-export type IntValueNode = Or<GraphQL.IntValueNode, {
-  readonly kind: Kind.INT;
-  readonly value: string;
-  readonly loc?: Location;
-}>;
+export type IntValueNode = Or<
+  GraphQL.IntValueNode,
+  {
+    readonly kind: Kind.INT;
+    readonly value: string;
+    readonly loc?: Location;
+  }
+>;
 
-export type FloatValueNode = Or<GraphQL.FloatValueNode, {
-  readonly kind: Kind.FLOAT;
-  readonly value: string;
-  readonly loc?: Location;
-}>;
+export type FloatValueNode = Or<
+  GraphQL.FloatValueNode,
+  {
+    readonly kind: Kind.FLOAT;
+    readonly value: string;
+    readonly loc?: Location;
+  }
+>;
 
-export type StringValueNode = Or<GraphQL.FloatValueNode, {
-  readonly kind: Kind.STRING;
-  readonly value: string;
-  readonly block?: boolean;
-  readonly loc?: Location;
-}>;
+export type StringValueNode = Or<
+  GraphQL.FloatValueNode,
+  {
+    readonly kind: Kind.STRING;
+    readonly value: string;
+    readonly block?: boolean;
+    readonly loc?: Location;
+  }
+>;
 
-export type BooleanValueNode = Or<GraphQL.BooleanValueNode, {
-  readonly kind: Kind.BOOLEAN;
-  readonly value: boolean;
-  readonly loc?: Location;
-}>;
+export type BooleanValueNode = Or<
+  GraphQL.BooleanValueNode,
+  {
+    readonly kind: Kind.BOOLEAN;
+    readonly value: boolean;
+    readonly loc?: Location;
+  }
+>;
 
-export type NullValueNode = Or<GraphQL.NullValueNode, {
-  readonly kind: Kind.NULL;
-  readonly loc?: Location;
-}>;
+export type NullValueNode = Or<
+  GraphQL.NullValueNode,
+  {
+    readonly kind: Kind.NULL;
+    readonly loc?: Location;
+  }
+>;
 
-export type EnumValueNode = Or<GraphQL.EnumValueNode, {
-  readonly kind: Kind.ENUM;
-  readonly value: string;
-  readonly loc?: Location;
-}>;
+export type EnumValueNode = Or<
+  GraphQL.EnumValueNode,
+  {
+    readonly kind: Kind.ENUM;
+    readonly value: string;
+    readonly loc?: Location;
+  }
+>;
 
-export type ListValueNode = Or<GraphQL.ListValueNode, {
-  readonly kind: Kind.LIST;
-  readonly values: ReadonlyArray<ValueNode>;
-  readonly loc?: Location;
-}>;
+export type ListValueNode = Or<
+  GraphQL.ListValueNode,
+  {
+    readonly kind: Kind.LIST;
+    readonly values: ReadonlyArray<ValueNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type ConstListValueNode = Or<GraphQL.ConstListValueNode, {
-  readonly kind: Kind.LIST;
-  readonly values: ReadonlyArray<ConstValueNode>;
-  readonly loc?: Location;
-}>;
+export type ConstListValueNode = Or<
+  GraphQL.ConstListValueNode,
+  {
+    readonly kind: Kind.LIST;
+    readonly values: ReadonlyArray<ConstValueNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type ObjectValueNode = Or<GraphQL.ObjectValueNode, {
-  readonly kind: Kind.OBJECT;
-  readonly fields: ReadonlyArray<ObjectFieldNode>;
-  readonly loc?: Location;
-}>;
+export type ObjectValueNode = Or<
+  GraphQL.ObjectValueNode,
+  {
+    readonly kind: Kind.OBJECT;
+    readonly fields: ReadonlyArray<ObjectFieldNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type ConstObjectValueNode = Or<GraphQL.ConstObjectValueNode, {
-  readonly kind: Kind.OBJECT;
-  readonly fields: ReadonlyArray<ConstObjectFieldNode>;
-  readonly loc?: Location;
-}>;
+export type ConstObjectValueNode = Or<
+  GraphQL.ConstObjectValueNode,
+  {
+    readonly kind: Kind.OBJECT;
+    readonly fields: ReadonlyArray<ConstObjectFieldNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type ObjectFieldNode = Or<GraphQL.ObjectFieldNode, {
-  readonly kind: Kind.OBJECT_FIELD;
-  readonly name: NameNode;
-  readonly value: ValueNode;
-  readonly loc?: Location;
-}>;
+export type ObjectFieldNode = Or<
+  GraphQL.ObjectFieldNode,
+  {
+    readonly kind: Kind.OBJECT_FIELD;
+    readonly name: NameNode;
+    readonly value: ValueNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type ConstObjectFieldNode = Or<GraphQL.ConstObjectFieldNode, {
-  readonly kind: Kind.OBJECT_FIELD;
-  readonly name: NameNode;
-  readonly value: ConstValueNode;
-  readonly loc?: Location;
-}>;
+export type ConstObjectFieldNode = Or<
+  GraphQL.ConstObjectFieldNode,
+  {
+    readonly kind: Kind.OBJECT_FIELD;
+    readonly name: NameNode;
+    readonly value: ConstValueNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type DirectiveNode = Or<GraphQL.DirectiveNode, {
-  readonly kind: Kind.DIRECTIVE;
-  readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ArgumentNode>;
-  readonly loc?: Location;
-}>;
+export type DirectiveNode = Or<
+  GraphQL.DirectiveNode,
+  {
+    readonly kind: Kind.DIRECTIVE;
+    readonly name: NameNode;
+    readonly arguments?: ReadonlyArray<ArgumentNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type ConstDirectiveNode = Or<GraphQL.ConstDirectiveNode, {
-  readonly kind: Kind.DIRECTIVE;
-  readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ConstArgumentNode>;
-  readonly loc?: Location;
-}>;
+export type ConstDirectiveNode = Or<
+  GraphQL.ConstDirectiveNode,
+  {
+    readonly kind: Kind.DIRECTIVE;
+    readonly name: NameNode;
+    readonly arguments?: ReadonlyArray<ConstArgumentNode>;
+    readonly loc?: Location;
+  }
+>;
 
-export type TypeNode = Or<GraphQL.TypeNode, (
-  | NamedTypeNode
-  | ListTypeNode
-  | NonNullTypeNode
-)>;
+export type TypeNode = Or<GraphQL.TypeNode, NamedTypeNode | ListTypeNode | NonNullTypeNode>;
 
-export type NamedTypeNode = Or<GraphQL.NamedTypeNode, {
-  readonly kind: Kind.NAMED_TYPE;
-  readonly name: NameNode;
-  readonly loc?: Location;
-}>;
+export type NamedTypeNode = Or<
+  GraphQL.NamedTypeNode,
+  {
+    readonly kind: Kind.NAMED_TYPE;
+    readonly name: NameNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type ListTypeNode = Or<GraphQL.ListTypeNode, {
-  readonly kind: Kind.LIST_TYPE;
-  readonly type: TypeNode;
-  readonly loc?: Location;
-}>;
+export type ListTypeNode = Or<
+  GraphQL.ListTypeNode,
+  {
+    readonly kind: Kind.LIST_TYPE;
+    readonly type: TypeNode;
+    readonly loc?: Location;
+  }
+>;
 
-export type NonNullTypeNode = Or<GraphQL.NonNullTypeNode, {
-  readonly kind: Kind.NON_NULL_TYPE;
-  readonly type: NamedTypeNode | ListTypeNode;
-  readonly loc?: Location;
-}>;
+export type NonNullTypeNode = Or<
+  GraphQL.NonNullTypeNode,
+  {
+    readonly kind: Kind.NON_NULL_TYPE;
+    readonly type: NamedTypeNode | ListTypeNode;
+    readonly loc?: Location;
+  }
+>;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,5 +1,7 @@
+import type * as GraphQL from 'graphql';
+
 import type { Kind, OperationTypeNode } from './kind';
-import type { Location } from './types';
+import type { OrNever, Location } from './types';
 
 import type {
   TypeSystemDefinitionNode,
@@ -68,28 +70,33 @@ export type ASTNode =
   | InterfaceTypeExtensionNode
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
-  | InputObjectTypeExtensionNode;
+  | InputObjectTypeExtensionNode
+  | OrNever<GraphQL.ASTNode>;
 
-export interface NameNode {
+export type NameNode = {
   readonly kind: Kind.NAME;
   readonly value: string;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.NameNode>;
 
-export interface DocumentNode {
+export type DocumentNode = {
   readonly kind: Kind.DOCUMENT;
   readonly definitions: ReadonlyArray<DefinitionNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.NameNode>;
 
 export type DefinitionNode =
   | ExecutableDefinitionNode
   | TypeSystemDefinitionNode
-  | TypeSystemExtensionNode;
+  | TypeSystemExtensionNode
+  | OrNever<GraphQL.DefinitionNode>;
 
-export type ExecutableDefinitionNode = OperationDefinitionNode | FragmentDefinitionNode;
+export type ExecutableDefinitionNode =
+  | OperationDefinitionNode
+  | FragmentDefinitionNode
+  | OrNever<GraphQL.ExecutableDefinitionNode>;
 
-export interface OperationDefinitionNode {
+export type OperationDefinitionNode = {
   readonly kind: Kind.OPERATION_DEFINITION;
   readonly operation: OperationTypeNode;
   readonly name?: NameNode;
@@ -97,32 +104,36 @@ export interface OperationDefinitionNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.OperationDefinitionNode>;
 
-export interface VariableDefinitionNode {
+export type VariableDefinitionNode = {
   readonly kind: Kind.VARIABLE_DEFINITION;
   readonly variable: VariableNode;
   readonly type: TypeNode;
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.VariableDefinitionNode>;
 
-export interface VariableNode {
+export type VariableNode = {
   readonly kind: Kind.VARIABLE;
   readonly name: NameNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.VariableNode>;
 
-export interface SelectionSetNode {
+export type SelectionSetNode = {
   readonly kind: Kind.SELECTION_SET;
   readonly selections: ReadonlyArray<SelectionNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.SelectionSetNode>;
 
-export declare type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
+export declare type SelectionNode =
+  | FieldNode
+  | FragmentSpreadNode
+  | InlineFragmentNode
+  | OrNever<GraphQL.SelectionNode>;
 
-export interface FieldNode {
+export type FieldNode = {
   readonly kind: Kind.FIELD;
   readonly alias?: NameNode;
   readonly name: NameNode;
@@ -130,45 +141,45 @@ export interface FieldNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet?: SelectionSetNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.FieldNode>
 
-export interface ArgumentNode {
+export type ArgumentNode = {
   readonly kind: Kind.ARGUMENT;
   readonly name: NameNode;
   readonly value: ValueNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ArgumentNode>;
 
-export interface ConstArgumentNode {
+export type ConstArgumentNode = {
   readonly kind: Kind.ARGUMENT;
   readonly name: NameNode;
   readonly value: ConstValueNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ConstArgumentNode>;
 
-export interface FragmentSpreadNode {
+export type FragmentSpreadNode = {
   readonly kind: Kind.FRAGMENT_SPREAD;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.FragmentSpreadNode>;
 
-export interface InlineFragmentNode {
+export type InlineFragmentNode = {
   readonly kind: Kind.INLINE_FRAGMENT;
   readonly typeCondition?: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.InlineFragmentNode>;
 
-export interface FragmentDefinitionNode {
+export type FragmentDefinitionNode = {
   readonly kind: Kind.FRAGMENT_DEFINITION;
   readonly name: NameNode;
   readonly typeCondition: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.FragmentDefinitionNode>;
 
 export type ValueNode =
   | VariableNode
@@ -179,7 +190,8 @@ export type ValueNode =
   | NullValueNode
   | EnumValueNode
   | ListValueNode
-  | ObjectValueNode;
+  | ObjectValueNode
+  | OrNever<GraphQL.ValueNode>;
 
 export type ConstValueNode =
   | IntValueNode
@@ -189,112 +201,117 @@ export type ConstValueNode =
   | NullValueNode
   | EnumValueNode
   | ConstListValueNode
-  | ConstObjectValueNode;
+  | ConstObjectValueNode
+  | OrNever<GraphQL.ConstValueNode>;
 
-export interface IntValueNode {
+export type IntValueNode = {
   readonly kind: Kind.INT;
   readonly value: string;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.IntValueNode>;
 
-export interface FloatValueNode {
+export type FloatValueNode = {
   readonly kind: Kind.FLOAT;
   readonly value: string;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.FloatValueNode>;
 
-export interface StringValueNode {
+export type StringValueNode = {
   readonly kind: Kind.STRING;
   readonly value: string;
   readonly block?: boolean;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.FloatValueNode>;
 
-export interface BooleanValueNode {
+export type BooleanValueNode = {
   readonly kind: Kind.BOOLEAN;
   readonly value: boolean;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.BooleanValueNode>;
 
-export interface NullValueNode {
+export type NullValueNode = {
   readonly kind: Kind.NULL;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.NullValueNode>;
 
-export interface EnumValueNode {
+export type EnumValueNode = {
   readonly kind: Kind.ENUM;
   readonly value: string;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.EnumValueNode>;
 
-export interface ListValueNode {
+export type ListValueNode = {
   readonly kind: Kind.LIST;
   readonly values: ReadonlyArray<ValueNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ListValueNode>;
 
-export interface ConstListValueNode {
+export type ConstListValueNode = {
   readonly kind: Kind.LIST;
   readonly values: ReadonlyArray<ConstValueNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ConstListValueNode>;
 
-export interface ObjectValueNode {
+export type ObjectValueNode = {
   readonly kind: Kind.OBJECT;
   readonly fields: ReadonlyArray<ObjectFieldNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ObjectValueNode>;
 
-export interface ConstObjectValueNode {
+export type ConstObjectValueNode = {
   readonly kind: Kind.OBJECT;
   readonly fields: ReadonlyArray<ConstObjectFieldNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ConstObjectValueNode>;
 
-export interface ObjectFieldNode {
+export type ObjectFieldNode = {
   readonly kind: Kind.OBJECT_FIELD;
   readonly name: NameNode;
   readonly value: ValueNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ObjectFieldNode>;
 
-export interface ConstObjectFieldNode {
+export type ConstObjectFieldNode = {
   readonly kind: Kind.OBJECT_FIELD;
   readonly name: NameNode;
   readonly value: ConstValueNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ConstObjectFieldNode>;
 
-export interface DirectiveNode {
+export type DirectiveNode = {
   readonly kind: Kind.DIRECTIVE;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ArgumentNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.DirectiveNode>;
 
-export interface ConstDirectiveNode {
+export type ConstDirectiveNode = {
   readonly kind: Kind.DIRECTIVE;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ConstArgumentNode>;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ConstDirectiveNode>;
 
-export declare type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
+export type TypeNode =
+  | NamedTypeNode
+  | ListTypeNode
+  | NonNullTypeNode
+  | OrNever<GraphQL.TypeNode>;
 
-export interface NamedTypeNode {
+export type NamedTypeNode = {
   readonly kind: Kind.NAMED_TYPE;
   readonly name: NameNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.NamedTypeNode>;
 
-export interface ListTypeNode {
+export type ListTypeNode = {
   readonly kind: Kind.LIST_TYPE;
   readonly type: TypeNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.ListTypeNode>;
 
-export interface NonNullTypeNode {
+export type NonNullTypeNode = {
   readonly kind: Kind.NON_NULL_TYPE;
   readonly type: NamedTypeNode | ListTypeNode;
   readonly loc?: Location;
-}
+} | OrNever<GraphQL.NonNullTypeNode>;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,7 +1,7 @@
 import type * as GraphQL from 'graphql';
 
 import type { Kind, OperationTypeNode } from './kind';
-import type { OrNever, Location } from './types';
+import type { Or, Location } from './types';
 
 import type {
   TypeSystemDefinitionNode,
@@ -27,7 +27,7 @@ import type {
   InputObjectTypeExtensionNode,
 } from './schemaAst';
 
-export type ASTNode =
+export type ASTNode = Or<GraphQL.ASTNode, (
   | NameNode
   | DocumentNode
   | OperationDefinitionNode
@@ -71,32 +71,32 @@ export type ASTNode =
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
-  | OrNever<GraphQL.ASTNode>;
+)>;
 
-export type NameNode = {
+export type NameNode = Or<GraphQL.NameNode, {
   readonly kind: Kind.NAME;
   readonly value: string;
   readonly loc?: Location;
-} | OrNever<GraphQL.NameNode>;
+}>;
 
-export type DocumentNode = {
+export type DocumentNode = Or<GraphQL.DocumentNode, {
   readonly kind: Kind.DOCUMENT;
   readonly definitions: ReadonlyArray<DefinitionNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.NameNode>;
+}>;
 
-export type DefinitionNode =
+export type DefinitionNode = Or<GraphQL.DefinitionNode, (
   | ExecutableDefinitionNode
   | TypeSystemDefinitionNode
   | TypeSystemExtensionNode
-  | OrNever<GraphQL.DefinitionNode>;
+)>;
 
-export type ExecutableDefinitionNode =
+export type ExecutableDefinitionNode = Or<GraphQL.ExecutableDefinitionNode, (
   | OperationDefinitionNode
   | FragmentDefinitionNode
-  | OrNever<GraphQL.ExecutableDefinitionNode>;
+)>;
 
-export type OperationDefinitionNode = {
+export type OperationDefinitionNode = Or<GraphQL.OperationDefinitionNode, {
   readonly kind: Kind.OPERATION_DEFINITION;
   readonly operation: OperationTypeNode;
   readonly name?: NameNode;
@@ -104,36 +104,36 @@ export type OperationDefinitionNode = {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.OperationDefinitionNode>;
+}>;
 
-export type VariableDefinitionNode = {
+export type VariableDefinitionNode = Or<GraphQL.VariableDefinitionNode, {
   readonly kind: Kind.VARIABLE_DEFINITION;
   readonly variable: VariableNode;
   readonly type: TypeNode;
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.VariableDefinitionNode>;
+}>;
 
-export type VariableNode = {
+export type VariableNode = Or<GraphQL.VariableNode, {
   readonly kind: Kind.VARIABLE;
   readonly name: NameNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.VariableNode>;
+}>;
 
-export type SelectionSetNode = {
+export type SelectionSetNode = Or<GraphQL.SelectionSetNode, {
   readonly kind: Kind.SELECTION_SET;
   readonly selections: ReadonlyArray<SelectionNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.SelectionSetNode>;
+}>;
 
-export declare type SelectionNode =
+export declare type SelectionNode = Or<GraphQL.SelectionNode, (
   | FieldNode
   | FragmentSpreadNode
   | InlineFragmentNode
-  | OrNever<GraphQL.SelectionNode>;
+)>;
 
-export type FieldNode = {
+export type FieldNode = Or<GraphQL.FieldNode, {
   readonly kind: Kind.FIELD;
   readonly alias?: NameNode;
   readonly name: NameNode;
@@ -141,47 +141,47 @@ export type FieldNode = {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet?: SelectionSetNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.FieldNode>
+}>;
 
-export type ArgumentNode = {
+export type ArgumentNode = Or<GraphQL.ArgumentNode, {
   readonly kind: Kind.ARGUMENT;
   readonly name: NameNode;
   readonly value: ValueNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.ArgumentNode>;
+}>;
 
-export type ConstArgumentNode = {
+export type ConstArgumentNode = Or<GraphQL.ConstArgumentNode, {
   readonly kind: Kind.ARGUMENT;
   readonly name: NameNode;
   readonly value: ConstValueNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.ConstArgumentNode>;
+}>;
 
-export type FragmentSpreadNode = {
+export type FragmentSpreadNode = Or<GraphQL.FragmentSpreadNode, {
   readonly kind: Kind.FRAGMENT_SPREAD;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.FragmentSpreadNode>;
+}>;
 
-export type InlineFragmentNode = {
+export type InlineFragmentNode = Or<GraphQL.InlineFragmentNode, {
   readonly kind: Kind.INLINE_FRAGMENT;
   readonly typeCondition?: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.InlineFragmentNode>;
+}>;
 
-export type FragmentDefinitionNode = {
+export type FragmentDefinitionNode = Or<GraphQL.FragmentDefinitionNode, {
   readonly kind: Kind.FRAGMENT_DEFINITION;
   readonly name: NameNode;
   readonly typeCondition: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.FragmentDefinitionNode>;
+}>;
 
-export type ValueNode =
+export type ValueNode = Or<GraphQL.ValueNode, (
   | VariableNode
   | IntValueNode
   | FloatValueNode
@@ -191,9 +191,9 @@ export type ValueNode =
   | EnumValueNode
   | ListValueNode
   | ObjectValueNode
-  | OrNever<GraphQL.ValueNode>;
+)>;
 
-export type ConstValueNode =
+export type ConstValueNode = Or<GraphQL.ConstValueNode, (
   | IntValueNode
   | FloatValueNode
   | StringValueNode
@@ -202,116 +202,116 @@ export type ConstValueNode =
   | EnumValueNode
   | ConstListValueNode
   | ConstObjectValueNode
-  | OrNever<GraphQL.ConstValueNode>;
+)>;
 
-export type IntValueNode = {
+export type IntValueNode = Or<GraphQL.IntValueNode, {
   readonly kind: Kind.INT;
   readonly value: string;
   readonly loc?: Location;
-} | OrNever<GraphQL.IntValueNode>;
+}>;
 
-export type FloatValueNode = {
+export type FloatValueNode = Or<GraphQL.FloatValueNode, {
   readonly kind: Kind.FLOAT;
   readonly value: string;
   readonly loc?: Location;
-} | OrNever<GraphQL.FloatValueNode>;
+}>;
 
-export type StringValueNode = {
+export type StringValueNode = Or<GraphQL.FloatValueNode, {
   readonly kind: Kind.STRING;
   readonly value: string;
   readonly block?: boolean;
   readonly loc?: Location;
-} | OrNever<GraphQL.FloatValueNode>;
+}>;
 
-export type BooleanValueNode = {
+export type BooleanValueNode = Or<GraphQL.BooleanValueNode, {
   readonly kind: Kind.BOOLEAN;
   readonly value: boolean;
   readonly loc?: Location;
-} | OrNever<GraphQL.BooleanValueNode>;
+}>;
 
-export type NullValueNode = {
+export type NullValueNode = Or<GraphQL.NullValueNode, {
   readonly kind: Kind.NULL;
   readonly loc?: Location;
-} | OrNever<GraphQL.NullValueNode>;
+}>;
 
-export type EnumValueNode = {
+export type EnumValueNode = Or<GraphQL.EnumValueNode, {
   readonly kind: Kind.ENUM;
   readonly value: string;
   readonly loc?: Location;
-} | OrNever<GraphQL.EnumValueNode>;
+}>;
 
-export type ListValueNode = {
+export type ListValueNode = Or<GraphQL.ListValueNode, {
   readonly kind: Kind.LIST;
   readonly values: ReadonlyArray<ValueNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.ListValueNode>;
+}>;
 
-export type ConstListValueNode = {
+export type ConstListValueNode = Or<GraphQL.ConstListValueNode, {
   readonly kind: Kind.LIST;
   readonly values: ReadonlyArray<ConstValueNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.ConstListValueNode>;
+}>;
 
-export type ObjectValueNode = {
+export type ObjectValueNode = Or<GraphQL.ObjectValueNode, {
   readonly kind: Kind.OBJECT;
   readonly fields: ReadonlyArray<ObjectFieldNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.ObjectValueNode>;
+}>;
 
-export type ConstObjectValueNode = {
+export type ConstObjectValueNode = Or<GraphQL.ConstObjectValueNode, {
   readonly kind: Kind.OBJECT;
   readonly fields: ReadonlyArray<ConstObjectFieldNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.ConstObjectValueNode>;
+}>;
 
-export type ObjectFieldNode = {
+export type ObjectFieldNode = Or<GraphQL.ObjectFieldNode, {
   readonly kind: Kind.OBJECT_FIELD;
   readonly name: NameNode;
   readonly value: ValueNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.ObjectFieldNode>;
+}>;
 
-export type ConstObjectFieldNode = {
+export type ConstObjectFieldNode = Or<GraphQL.ConstObjectFieldNode, {
   readonly kind: Kind.OBJECT_FIELD;
   readonly name: NameNode;
   readonly value: ConstValueNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.ConstObjectFieldNode>;
+}>;
 
-export type DirectiveNode = {
+export type DirectiveNode = Or<GraphQL.DirectiveNode, {
   readonly kind: Kind.DIRECTIVE;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ArgumentNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.DirectiveNode>;
+}>;
 
-export type ConstDirectiveNode = {
+export type ConstDirectiveNode = Or<GraphQL.ConstDirectiveNode, {
   readonly kind: Kind.DIRECTIVE;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ConstArgumentNode>;
   readonly loc?: Location;
-} | OrNever<GraphQL.ConstDirectiveNode>;
+}>;
 
-export type TypeNode =
+export type TypeNode = Or<GraphQL.TypeNode, (
   | NamedTypeNode
   | ListTypeNode
   | NonNullTypeNode
-  | OrNever<GraphQL.TypeNode>;
+)>;
 
-export type NamedTypeNode = {
+export type NamedTypeNode = Or<GraphQL.NamedTypeNode, {
   readonly kind: Kind.NAMED_TYPE;
   readonly name: NameNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.NamedTypeNode>;
+}>;
 
-export type ListTypeNode = {
+export type ListTypeNode = Or<GraphQL.ListTypeNode, {
   readonly kind: Kind.LIST_TYPE;
   readonly type: TypeNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.ListTypeNode>;
+}>;
 
-export type NonNullTypeNode = {
+export type NonNullTypeNode = Or<GraphQL.NonNullTypeNode, {
   readonly kind: Kind.NON_NULL_TYPE;
   readonly type: NamedTypeNode | ListTypeNode;
   readonly loc?: Location;
-} | OrNever<GraphQL.NonNullTypeNode>;
+}>;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -129,5 +129,5 @@ const nodes: {
 };
 
 export function print(node: ASTNode): string {
-  return nodes[node.kind] ? nodes[node.kind]!(node as any) : '';
+  return nodes[node.kind] ? (nodes as any)[node.kind]!(node) : '';
 }

--- a/src/schemaAst.ts
+++ b/src/schemaAst.ts
@@ -1,4 +1,6 @@
-import type { Location } from './types';
+import type * as GraphQL from 'graphql';
+
+import type { OrNever, Location } from './types';
 import type { Kind, OperationTypeNode } from './kind';
 
 import type {
@@ -14,22 +16,23 @@ import type {
 export declare type TypeSystemDefinitionNode =
   | SchemaDefinitionNode
   | TypeDefinitionNode
-  | DirectiveDefinitionNode;
+  | DirectiveDefinitionNode
+  | OrNever<GraphQL.TypeSystemDefinitionNode>;
 
-export interface SchemaDefinitionNode {
+export type SchemaDefinitionNode = {
   readonly kind: Kind.SCHEMA_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
-}
+} | OrNever<GraphQL.SchemaDefinitionNode>;
 
-export interface OperationTypeDefinitionNode {
+export type OperationTypeDefinitionNode = {
   readonly kind: Kind.OPERATION_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly operation: OperationTypeNode;
   readonly type: NamedTypeNode;
-}
+} | OrNever<GraphQL.OperationTypeDefinitionNode>;
 
 /** Type Definition */
 export declare type TypeDefinitionNode =
@@ -38,17 +41,18 @@ export declare type TypeDefinitionNode =
   | InterfaceTypeDefinitionNode
   | UnionTypeDefinitionNode
   | EnumTypeDefinitionNode
-  | InputObjectTypeDefinitionNode;
+  | InputObjectTypeDefinitionNode
+  | OrNever<GraphQL.TypeDefinitionNode>;
 
-export interface ScalarTypeDefinitionNode {
+export type ScalarTypeDefinitionNode = {
   readonly kind: Kind.SCALAR_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}
+} | OrNever<GraphQL.ScalarTypeDefinitionNode>;
 
-export interface ObjectTypeDefinitionNode {
+export type ObjectTypeDefinitionNode = {
   readonly kind: Kind.OBJECT_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -56,9 +60,9 @@ export interface ObjectTypeDefinitionNode {
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}
+} | OrNever<GraphQL.ObjectTypeDefinitionNode>;
 
-export interface FieldDefinitionNode {
+export type FieldDefinitionNode = {
   readonly kind: Kind.FIELD_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -66,9 +70,9 @@ export interface FieldDefinitionNode {
   readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
   readonly type: TypeNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}
+} | OrNever<GraphQL.FieldDefinitionNode>;
 
-export interface InputValueDefinitionNode {
+export type InputValueDefinitionNode = {
   readonly kind: Kind.INPUT_VALUE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -76,9 +80,9 @@ export interface InputValueDefinitionNode {
   readonly type: TypeNode;
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}
+} | OrNever<GraphQL.InputValueDefinitionNode>;
 
-export interface InterfaceTypeDefinitionNode {
+export type InterfaceTypeDefinitionNode = {
   readonly kind: Kind.INTERFACE_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -86,44 +90,45 @@ export interface InterfaceTypeDefinitionNode {
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}
+} | OrNever<GraphQL.InterfaceTypeDefinitionNode>;
 
-export interface UnionTypeDefinitionNode {
+export type UnionTypeDefinitionNode = {
   readonly kind: Kind.UNION_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
-}
+} | OrNever<GraphQL.UnionTypeDefinitionNode>;
 
-export interface EnumTypeDefinitionNode {
+export type EnumTypeDefinitionNode = {
   readonly kind: Kind.ENUM_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-}
+} | OrNever<GraphQL.EnumTypeDefinitionNode>;
 
-export interface EnumValueDefinitionNode {
+export type EnumValueDefinitionNode = {
   readonly kind: Kind.ENUM_VALUE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}
+} | OrNever<GraphQL.EnumValueDefinitionNode>;
 
-export interface InputObjectTypeDefinitionNode {
+export type InputObjectTypeDefinitionNode = {
   readonly kind: Kind.INPUT_OBJECT_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-}
+} | OrNever<GraphQL.InputObjectTypeDefinitionNode>;
+
 /** Directive Definitions */
-export interface DirectiveDefinitionNode {
+export type DirectiveDefinitionNode = {
   readonly kind: Kind.DIRECTIVE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -131,15 +136,21 @@ export interface DirectiveDefinitionNode {
   readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
   readonly repeatable: boolean;
   readonly locations: ReadonlyArray<NameNode>;
-}
+} | OrNever<GraphQL.DirectiveDefinitionNode>;
+
 /** Type System Extensions */
-export declare type TypeSystemExtensionNode = SchemaExtensionNode | TypeExtensionNode;
-export interface SchemaExtensionNode {
+export type TypeSystemExtensionNode =
+  | SchemaExtensionNode
+  | TypeExtensionNode
+  | OrNever<GraphQL.TypeSystemExtensionNode>;
+
+export type SchemaExtensionNode = {
   readonly kind: Kind.SCHEMA_EXTENSION;
   readonly loc?: Location;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
-}
+} | OrNever<GraphQL.SchemaExtensionNode>;
+
 /** Type Extensions */
 export declare type TypeExtensionNode =
   | ScalarTypeExtensionNode
@@ -147,52 +158,54 @@ export declare type TypeExtensionNode =
   | InterfaceTypeExtensionNode
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
-  | InputObjectTypeExtensionNode;
-export interface ScalarTypeExtensionNode {
+  | InputObjectTypeExtensionNode
+  | OrNever<GraphQL.TypeExtensionNode>;
+
+export type ScalarTypeExtensionNode = {
   readonly kind: Kind.SCALAR_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}
+} | OrNever<GraphQL.ScalarTypeExtensionNode>;
 
-export interface ObjectTypeExtensionNode {
+export type ObjectTypeExtensionNode = {
   readonly kind: Kind.OBJECT_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}
+} | OrNever<GraphQL.ObjectTypeExtensionNode>;
 
-export interface InterfaceTypeExtensionNode {
+export type InterfaceTypeExtensionNode = {
   readonly kind: Kind.INTERFACE_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}
+} | OrNever<GraphQL.InterfaceTypeExtensionNode>;
 
-export interface UnionTypeExtensionNode {
+export type UnionTypeExtensionNode = {
   readonly kind: Kind.UNION_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
-}
+} | OrNever<GraphQL.UnionTypeExtensionNode>;
 
-export interface EnumTypeExtensionNode {
+export type EnumTypeExtensionNode = {
   readonly kind: Kind.ENUM_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-}
+} | OrNever<GraphQL.EnumTypeExtensionNode>;
 
-export interface InputObjectTypeExtensionNode {
+export type InputObjectTypeExtensionNode = {
   readonly kind: Kind.INPUT_OBJECT_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-}
+} | OrNever<GraphQL.InputObjectTypeExtensionNode>;

--- a/src/schemaAst.ts
+++ b/src/schemaAst.ts
@@ -1,6 +1,6 @@
 import type * as GraphQL from 'graphql';
 
-import type { OrNever, Location } from './types';
+import type { Or, Location } from './types';
 import type { Kind, OperationTypeNode } from './kind';
 
 import type {
@@ -13,46 +13,46 @@ import type {
 } from './ast';
 
 /** Type System Definition */
-export declare type TypeSystemDefinitionNode =
+export declare type TypeSystemDefinitionNode = Or<GraphQL.TypeSystemDefinitionNode, (
   | SchemaDefinitionNode
   | TypeDefinitionNode
   | DirectiveDefinitionNode
-  | OrNever<GraphQL.TypeSystemDefinitionNode>;
+)>;
 
-export type SchemaDefinitionNode = {
+export type SchemaDefinitionNode = Or<GraphQL.SchemaDefinitionNode, {
   readonly kind: Kind.SCHEMA_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
-} | OrNever<GraphQL.SchemaDefinitionNode>;
+}>;
 
-export type OperationTypeDefinitionNode = {
+export type OperationTypeDefinitionNode = Or<GraphQL.OperationTypeDefinitionNode, {
   readonly kind: Kind.OPERATION_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly operation: OperationTypeNode;
   readonly type: NamedTypeNode;
-} | OrNever<GraphQL.OperationTypeDefinitionNode>;
+}>;
 
 /** Type Definition */
-export declare type TypeDefinitionNode =
+export declare type TypeDefinitionNode = Or<GraphQL.TypeDefinitionNode, (
   | ScalarTypeDefinitionNode
   | ObjectTypeDefinitionNode
   | InterfaceTypeDefinitionNode
   | UnionTypeDefinitionNode
   | EnumTypeDefinitionNode
   | InputObjectTypeDefinitionNode
-  | OrNever<GraphQL.TypeDefinitionNode>;
+)>;
 
-export type ScalarTypeDefinitionNode = {
+export type ScalarTypeDefinitionNode = Or<GraphQL.ScalarTypeDefinitionNode, {
   readonly kind: Kind.SCALAR_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-} | OrNever<GraphQL.ScalarTypeDefinitionNode>;
+}>;
 
-export type ObjectTypeDefinitionNode = {
+export type ObjectTypeDefinitionNode = Or<GraphQL.ObjectTypeDefinitionNode, {
   readonly kind: Kind.OBJECT_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -60,9 +60,9 @@ export type ObjectTypeDefinitionNode = {
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-} | OrNever<GraphQL.ObjectTypeDefinitionNode>;
+}>;
 
-export type FieldDefinitionNode = {
+export type FieldDefinitionNode = Or<GraphQL.FieldDefinitionNode, {
   readonly kind: Kind.FIELD_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -70,9 +70,9 @@ export type FieldDefinitionNode = {
   readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
   readonly type: TypeNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-} | OrNever<GraphQL.FieldDefinitionNode>;
+}>;
 
-export type InputValueDefinitionNode = {
+export type InputValueDefinitionNode = Or<GraphQL.InputValueDefinitionNode, {
   readonly kind: Kind.INPUT_VALUE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -80,9 +80,9 @@ export type InputValueDefinitionNode = {
   readonly type: TypeNode;
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-} | OrNever<GraphQL.InputValueDefinitionNode>;
+}>;
 
-export type InterfaceTypeDefinitionNode = {
+export type InterfaceTypeDefinitionNode = Or<GraphQL.InterfaceTypeDefinitionNode, {
   readonly kind: Kind.INTERFACE_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -90,45 +90,44 @@ export type InterfaceTypeDefinitionNode = {
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-} | OrNever<GraphQL.InterfaceTypeDefinitionNode>;
+}>;
 
-export type UnionTypeDefinitionNode = {
+export type UnionTypeDefinitionNode = Or<GraphQL.UnionTypeDefinitionNode, {
   readonly kind: Kind.UNION_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
-} | OrNever<GraphQL.UnionTypeDefinitionNode>;
+}>;
 
-export type EnumTypeDefinitionNode = {
+export type EnumTypeDefinitionNode = Or<GraphQL.EnumTypeDefinitionNode, {
   readonly kind: Kind.ENUM_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-} | OrNever<GraphQL.EnumTypeDefinitionNode>;
+}>;
 
-export type EnumValueDefinitionNode = {
+export type EnumValueDefinitionNode = Or<GraphQL.EnumValueDefinitionNode, {
   readonly kind: Kind.ENUM_VALUE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-} | OrNever<GraphQL.EnumValueDefinitionNode>;
+}>;
 
-export type InputObjectTypeDefinitionNode = {
+export type InputObjectTypeDefinitionNode = Or<GraphQL.InputObjectTypeDefinitionNode, {
   readonly kind: Kind.INPUT_OBJECT_TYPE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-} | OrNever<GraphQL.InputObjectTypeDefinitionNode>;
+}>;
 
-/** Directive Definitions */
-export type DirectiveDefinitionNode = {
+export type DirectiveDefinitionNode = Or<GraphQL.DirectiveDefinitionNode, {
   readonly kind: Kind.DIRECTIVE_DEFINITION;
   readonly loc?: Location;
   readonly description?: StringValueNode;
@@ -136,76 +135,74 @@ export type DirectiveDefinitionNode = {
   readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
   readonly repeatable: boolean;
   readonly locations: ReadonlyArray<NameNode>;
-} | OrNever<GraphQL.DirectiveDefinitionNode>;
+}>;
 
-/** Type System Extensions */
-export type TypeSystemExtensionNode =
+export type TypeSystemExtensionNode = Or<GraphQL.TypeSystemExtensionNode, (
   | SchemaExtensionNode
   | TypeExtensionNode
-  | OrNever<GraphQL.TypeSystemExtensionNode>;
+)>;
 
-export type SchemaExtensionNode = {
+export type SchemaExtensionNode = Or<GraphQL.SchemaExtensionNode, {
   readonly kind: Kind.SCHEMA_EXTENSION;
   readonly loc?: Location;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
-} | OrNever<GraphQL.SchemaExtensionNode>;
+}>;
 
-/** Type Extensions */
-export declare type TypeExtensionNode =
+export declare type TypeExtensionNode = Or<GraphQL.TypeExtensionNode, (
   | ScalarTypeExtensionNode
   | ObjectTypeExtensionNode
   | InterfaceTypeExtensionNode
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
-  | OrNever<GraphQL.TypeExtensionNode>;
+)>;
 
-export type ScalarTypeExtensionNode = {
+export type ScalarTypeExtensionNode = Or<GraphQL.ScalarTypeExtensionNode, {
   readonly kind: Kind.SCALAR_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-} | OrNever<GraphQL.ScalarTypeExtensionNode>;
+}>;
 
-export type ObjectTypeExtensionNode = {
+export type ObjectTypeExtensionNode = Or<GraphQL.ObjectTypeExtensionNode, {
   readonly kind: Kind.OBJECT_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-} | OrNever<GraphQL.ObjectTypeExtensionNode>;
+}>;
 
-export type InterfaceTypeExtensionNode = {
+export type InterfaceTypeExtensionNode = Or<GraphQL.InterfaceTypeExtensionNode, {
   readonly kind: Kind.INTERFACE_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-} | OrNever<GraphQL.InterfaceTypeExtensionNode>;
+}>;
 
-export type UnionTypeExtensionNode = {
+export type UnionTypeExtensionNode = Or<GraphQL.UnionTypeExtensionNode, {
   readonly kind: Kind.UNION_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
-} | OrNever<GraphQL.UnionTypeExtensionNode>;
+}>;
 
-export type EnumTypeExtensionNode = {
+export type EnumTypeExtensionNode = Or<GraphQL.EnumTypeExtensionNode, {
   readonly kind: Kind.ENUM_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-} | OrNever<GraphQL.EnumTypeExtensionNode>;
+}>;
 
-export type InputObjectTypeExtensionNode = {
+export type InputObjectTypeExtensionNode = Or<GraphQL.InputObjectTypeExtensionNode, {
   readonly kind: Kind.INPUT_OBJECT_TYPE_EXTENSION;
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-} | OrNever<GraphQL.InputObjectTypeExtensionNode>;
+}>;

--- a/src/schemaAst.ts
+++ b/src/schemaAst.ts
@@ -13,196 +13,254 @@ import type {
 } from './ast';
 
 /** Type System Definition */
-export declare type TypeSystemDefinitionNode = Or<GraphQL.TypeSystemDefinitionNode, (
-  | SchemaDefinitionNode
-  | TypeDefinitionNode
-  | DirectiveDefinitionNode
-)>;
+export declare type TypeSystemDefinitionNode = Or<
+  GraphQL.TypeSystemDefinitionNode,
+  SchemaDefinitionNode | TypeDefinitionNode | DirectiveDefinitionNode
+>;
 
-export type SchemaDefinitionNode = Or<GraphQL.SchemaDefinitionNode, {
-  readonly kind: Kind.SCHEMA_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
-}>;
+export type SchemaDefinitionNode = Or<
+  GraphQL.SchemaDefinitionNode,
+  {
+    readonly kind: Kind.SCHEMA_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
+  }
+>;
 
-export type OperationTypeDefinitionNode = Or<GraphQL.OperationTypeDefinitionNode, {
-  readonly kind: Kind.OPERATION_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly operation: OperationTypeNode;
-  readonly type: NamedTypeNode;
-}>;
+export type OperationTypeDefinitionNode = Or<
+  GraphQL.OperationTypeDefinitionNode,
+  {
+    readonly kind: Kind.OPERATION_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly operation: OperationTypeNode;
+    readonly type: NamedTypeNode;
+  }
+>;
 
 /** Type Definition */
-export declare type TypeDefinitionNode = Or<GraphQL.TypeDefinitionNode, (
+export declare type TypeDefinitionNode = Or<
+  GraphQL.TypeDefinitionNode,
   | ScalarTypeDefinitionNode
   | ObjectTypeDefinitionNode
   | InterfaceTypeDefinitionNode
   | UnionTypeDefinitionNode
   | EnumTypeDefinitionNode
   | InputObjectTypeDefinitionNode
-)>;
+>;
 
-export type ScalarTypeDefinitionNode = Or<GraphQL.ScalarTypeDefinitionNode, {
-  readonly kind: Kind.SCALAR_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}>;
+export type ScalarTypeDefinitionNode = Or<
+  GraphQL.ScalarTypeDefinitionNode,
+  {
+    readonly kind: Kind.SCALAR_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  }
+>;
 
-export type ObjectTypeDefinitionNode = Or<GraphQL.ObjectTypeDefinitionNode, {
-  readonly kind: Kind.OBJECT_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}>;
+export type ObjectTypeDefinitionNode = Or<
+  GraphQL.ObjectTypeDefinitionNode,
+  {
+    readonly kind: Kind.OBJECT_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly interfaces?: ReadonlyArray<NamedTypeNode>;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  }
+>;
 
-export type FieldDefinitionNode = Or<GraphQL.FieldDefinitionNode, {
-  readonly kind: Kind.FIELD_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
-  readonly type: TypeNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}>;
+export type FieldDefinitionNode = Or<
+  GraphQL.FieldDefinitionNode,
+  {
+    readonly kind: Kind.FIELD_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
+    readonly type: TypeNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  }
+>;
 
-export type InputValueDefinitionNode = Or<GraphQL.InputValueDefinitionNode, {
-  readonly kind: Kind.INPUT_VALUE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly type: TypeNode;
-  readonly defaultValue?: ConstValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}>;
+export type InputValueDefinitionNode = Or<
+  GraphQL.InputValueDefinitionNode,
+  {
+    readonly kind: Kind.INPUT_VALUE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly type: TypeNode;
+    readonly defaultValue?: ConstValueNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  }
+>;
 
-export type InterfaceTypeDefinitionNode = Or<GraphQL.InterfaceTypeDefinitionNode, {
-  readonly kind: Kind.INTERFACE_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}>;
+export type InterfaceTypeDefinitionNode = Or<
+  GraphQL.InterfaceTypeDefinitionNode,
+  {
+    readonly kind: Kind.INTERFACE_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly interfaces?: ReadonlyArray<NamedTypeNode>;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  }
+>;
 
-export type UnionTypeDefinitionNode = Or<GraphQL.UnionTypeDefinitionNode, {
-  readonly kind: Kind.UNION_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly types?: ReadonlyArray<NamedTypeNode>;
-}>;
+export type UnionTypeDefinitionNode = Or<
+  GraphQL.UnionTypeDefinitionNode,
+  {
+    readonly kind: Kind.UNION_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly types?: ReadonlyArray<NamedTypeNode>;
+  }
+>;
 
-export type EnumTypeDefinitionNode = Or<GraphQL.EnumTypeDefinitionNode, {
-  readonly kind: Kind.ENUM_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-}>;
+export type EnumTypeDefinitionNode = Or<
+  GraphQL.EnumTypeDefinitionNode,
+  {
+    readonly kind: Kind.ENUM_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
+  }
+>;
 
-export type EnumValueDefinitionNode = Or<GraphQL.EnumValueDefinitionNode, {
-  readonly kind: Kind.ENUM_VALUE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}>;
+export type EnumValueDefinitionNode = Or<
+  GraphQL.EnumValueDefinitionNode,
+  {
+    readonly kind: Kind.ENUM_VALUE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  }
+>;
 
-export type InputObjectTypeDefinitionNode = Or<GraphQL.InputObjectTypeDefinitionNode, {
-  readonly kind: Kind.INPUT_OBJECT_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-}>;
+export type InputObjectTypeDefinitionNode = Or<
+  GraphQL.InputObjectTypeDefinitionNode,
+  {
+    readonly kind: Kind.INPUT_OBJECT_TYPE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
+  }
+>;
 
-export type DirectiveDefinitionNode = Or<GraphQL.DirectiveDefinitionNode, {
-  readonly kind: Kind.DIRECTIVE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
-  readonly repeatable: boolean;
-  readonly locations: ReadonlyArray<NameNode>;
-}>;
+export type DirectiveDefinitionNode = Or<
+  GraphQL.DirectiveDefinitionNode,
+  {
+    readonly kind: Kind.DIRECTIVE_DEFINITION;
+    readonly loc?: Location;
+    readonly description?: StringValueNode;
+    readonly name: NameNode;
+    readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
+    readonly repeatable: boolean;
+    readonly locations: ReadonlyArray<NameNode>;
+  }
+>;
 
-export type TypeSystemExtensionNode = Or<GraphQL.TypeSystemExtensionNode, (
-  | SchemaExtensionNode
-  | TypeExtensionNode
-)>;
+export type TypeSystemExtensionNode = Or<
+  GraphQL.TypeSystemExtensionNode,
+  SchemaExtensionNode | TypeExtensionNode
+>;
 
-export type SchemaExtensionNode = Or<GraphQL.SchemaExtensionNode, {
-  readonly kind: Kind.SCHEMA_EXTENSION;
-  readonly loc?: Location;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
-}>;
+export type SchemaExtensionNode = Or<
+  GraphQL.SchemaExtensionNode,
+  {
+    readonly kind: Kind.SCHEMA_EXTENSION;
+    readonly loc?: Location;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
+  }
+>;
 
-export declare type TypeExtensionNode = Or<GraphQL.TypeExtensionNode, (
+export declare type TypeExtensionNode = Or<
+  GraphQL.TypeExtensionNode,
   | ScalarTypeExtensionNode
   | ObjectTypeExtensionNode
   | InterfaceTypeExtensionNode
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
-)>;
+>;
 
-export type ScalarTypeExtensionNode = Or<GraphQL.ScalarTypeExtensionNode, {
-  readonly kind: Kind.SCALAR_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-}>;
+export type ScalarTypeExtensionNode = Or<
+  GraphQL.ScalarTypeExtensionNode,
+  {
+    readonly kind: Kind.SCALAR_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  }
+>;
 
-export type ObjectTypeExtensionNode = Or<GraphQL.ObjectTypeExtensionNode, {
-  readonly kind: Kind.OBJECT_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}>;
+export type ObjectTypeExtensionNode = Or<
+  GraphQL.ObjectTypeExtensionNode,
+  {
+    readonly kind: Kind.OBJECT_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly interfaces?: ReadonlyArray<NamedTypeNode>;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  }
+>;
 
-export type InterfaceTypeExtensionNode = Or<GraphQL.InterfaceTypeExtensionNode, {
-  readonly kind: Kind.INTERFACE_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
-}>;
+export type InterfaceTypeExtensionNode = Or<
+  GraphQL.InterfaceTypeExtensionNode,
+  {
+    readonly kind: Kind.INTERFACE_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly interfaces?: ReadonlyArray<NamedTypeNode>;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  }
+>;
 
-export type UnionTypeExtensionNode = Or<GraphQL.UnionTypeExtensionNode, {
-  readonly kind: Kind.UNION_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly types?: ReadonlyArray<NamedTypeNode>;
-}>;
+export type UnionTypeExtensionNode = Or<
+  GraphQL.UnionTypeExtensionNode,
+  {
+    readonly kind: Kind.UNION_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly types?: ReadonlyArray<NamedTypeNode>;
+  }
+>;
 
-export type EnumTypeExtensionNode = Or<GraphQL.EnumTypeExtensionNode, {
-  readonly kind: Kind.ENUM_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
-}>;
+export type EnumTypeExtensionNode = Or<
+  GraphQL.EnumTypeExtensionNode,
+  {
+    readonly kind: Kind.ENUM_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
+  }
+>;
 
-export type InputObjectTypeExtensionNode = Or<GraphQL.InputObjectTypeExtensionNode, {
-  readonly kind: Kind.INPUT_OBJECT_TYPE_EXTENSION;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
-}>;
+export type InputObjectTypeExtensionNode = Or<
+  GraphQL.InputObjectTypeExtensionNode,
+  {
+    readonly kind: Kind.INPUT_OBJECT_TYPE_EXTENSION;
+    readonly loc?: Location;
+    readonly name: NameNode;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+    readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
+  }
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type OrNever<T> = 0 extends 1 & T ? never : T;
+export type Or<T, U> = 0 extends 1 & T ? U : T;
 
 export type Maybe<T> = T | undefined | null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type OrNever<T> = 0 extends 1 & T ? never : T;
+
 export type Maybe<T> = T | undefined | null;
 
 export interface Extensions {


### PR DESCRIPTION
This imports types from `'graphql'` and extends all local AST types with them. An added `ts-ignore` pragma is added in the output to ensure that this also works when `'graphql'` isn't installed.