### PR TITLE
fix: Fix Safari 10–13 sticky regular expression quirks

### DIFF
--- a/.changeset/curvy-geese-hope.md
+++ b/.changeset/curvy-geese-hope.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Fix browser quirk occurring in Safari 10–13 causing sticky regular expressions in the parser to match when they shouldn't / match too eagerly.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -76,7 +76,9 @@ function name(): ast.NameNode | undefined {
   }
 }
 
-const constRe = /null|true|false/y;
+// NOTE(Safari10 Quirk): This needs to be wrapped in a non-capturing group
+const constRe = /(?:null|true|false)/y;
+
 const variableRe = /\$[_\w][_\d\w]*/y;
 const intRe = /-?\d+/y;
 const floatPartRe = /(?:\.\d+)?(?:[eE][+-]?\d+)?/y;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -65,7 +65,7 @@ function ignored() {
   idx--;
 }
 
-const nameRe = /[_\w][_\d\w]*/y;
+const nameRe = /[_A-Za-z]\w*/y;
 function name(): ast.NameNode | undefined {
   let match: string | undefined;
   if ((match = advance(nameRe))) {
@@ -79,7 +79,7 @@ function name(): ast.NameNode | undefined {
 // NOTE(Safari10 Quirk): This needs to be wrapped in a non-capturing group
 const constRe = /(?:null|true|false)/y;
 
-const variableRe = /\$[_\w][_\d\w]*/y;
+const variableRe = /\$[_A-Za-z]\w*/y;
 const intRe = /-?\d+/y;
 
 // NOTE(Safari10 Quirk): This cannot be further simplified

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -81,7 +81,10 @@ const constRe = /(?:null|true|false)/y;
 
 const variableRe = /\$[_\w][_\d\w]*/y;
 const intRe = /-?\d+/y;
-const floatPartRe = /(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+
+// NOTE(Safari10 Quirk): This cannot be further simplified
+const floatPartRe = /(?:\.\d+)?[eE][+-]?\d+|\.\d+/y;
+
 const complexStringRe = /\\/g;
 const blockStringRe = /"""(?:[\s\S]+(?="""))?"""/y;
 const stringRe = /"(?:[^"\r\n]+)?"/y;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -418,7 +418,9 @@ function fragmentDefinition(): ast.FragmentDefinitionNode | undefined {
   }
 }
 
-const operationDefinitionRe = /query|mutation|subscription/y;
+// NOTE(Safari10 Quirk): This *might* need to be wrapped in a group, but worked without it too
+const operationDefinitionRe = /(?:query|mutation|subscription)/y;
+
 function operationDefinition(): ast.OperationDefinitionNode | undefined {
   let _operation: string | undefined;
   let _name: ast.NameNode | undefined;


### PR DESCRIPTION
Resolves #14

## Summary

This resolves quirks that occur with Safari 10–13’s implementation of sticky regular expressions. It may not be a comprehensive fix, nor do I have an explanation for this.

The following regular expressions seem to match/test positively, when they shouldn't:

```js
/null|true|false/y;
/(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
/query|mutation|subscription/y;
```

The last one in this list actually doesn't, which further confuses me.
Either way, they can all be fixed by slightly rewriting them.

## Set of changes

- Wrap `constRe`'s pattern in a non-capturing group
- Wrap `operationDefinitionRe`'s pattern in a non-capturing group
- Rewrite `floatPartRe`'s pattern to strictly always be non-empty
- UNRELATED: Update word patterns to use `\w` more sparingly and accurately
