### PR TITLE
Fix string and block string matches being too eager

### DIFF
--- a/.changeset/loud-countries-mix.md
+++ b/.changeset/loud-countries-mix.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Fix string and block string matches eagerly matching past the end boundary of strings and ignoring escaped closing characters. In certain cases, `"""` and `"` boundaries would be skipped if any other string boundary follows in the input document.

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -478,6 +478,18 @@ describe('parseValue', () => {
       value: '\t\t',
       block: false,
     });
+
+    expect(parseValue('" \\" "')).toEqual({
+      kind: Kind.STRING,
+      value: ' " ',
+      block: false,
+    });
+
+    expect(parseValue('"x" "x"')).toEqual({
+      kind: Kind.STRING,
+      value: 'x',
+      block: false,
+    });
   });
 
   it('parses objects', () => {
@@ -546,6 +558,18 @@ describe('parseValue', () => {
     expect(parseValue('"""\n\n  first\n  second\n"""')).toEqual({
       kind: Kind.STRING,
       value: 'first\nsecond',
+      block: true,
+    });
+
+    expect(parseValue('""" \\""" """')).toEqual({
+      kind: Kind.STRING,
+      value: ' """ ',
+      block: true,
+    });
+
+    expect(parseValue('"""x""" """x"""')).toEqual({
+      kind: Kind.STRING,
+      value: 'x',
       block: true,
     });
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -86,8 +86,8 @@ const intRe = /-?\d+/y;
 const floatPartRe = /(?:\.\d+)?[eE][+-]?\d+|\.\d+/y;
 
 const complexStringRe = /\\/g;
-const blockStringRe = /"""(?:[\s\S]+(?="""))?"""/y;
-const stringRe = /"(?:[^"\r\n]+)?"/y;
+const blockStringRe = /"""(?:[\s\S]*?[^\\])?"""/y;
+const stringRe = /"(?:[^\r\n]*?[^\\])?"/y;
 
 function value(constant: true): ast.ConstValueNode;
 function value(constant: boolean): ast.ValueNode;


### PR DESCRIPTION
## Summary

Certain cases could cause the `stringRe` and `blockStringRe` to match too eagerly.
Specifically, if a block string was followed by another, it would match until the end of the last block string in the document. This was because of a faulty escaped end character match `\"""`.

The regular string matcher had a very similar issue that needed fixing.

Both cases were tested against Safari 10.

## Set of changes

- Update `stringRe`
- Update `blockStringRe`
- Add tests
