### PR TITLE
refactor: Improve `print` performance

### DIFF
--- a/.changeset/three-buttons-eat.md
+++ b/.changeset/three-buttons-eat.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Improve printer performance.

--- a/src/__tests__/visitor.bench.ts
+++ b/src/__tests__/visitor.bench.ts
@@ -7,7 +7,7 @@ import * as graphql17 from 'graphql17';
 import kitchenSinkAST from './fixtures/kitchen_sink.json';
 import { visit } from '../visitor';
 
-describe('print (kitchen sink AST)', () => {
+describe('visit (kitchen sink AST)', () => {
   bench('@0no-co/graphql.web', () => {
     visit(kitchenSinkAST, {
       Field: formatNode,

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -260,7 +260,7 @@ export type FloatValueNode = Or<
 >;
 
 export type StringValueNode = Or<
-  GraphQL.FloatValueNode,
+  GraphQL.StringValueNode,
   {
     readonly kind: Kind.STRING;
     readonly value: string;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -151,8 +151,6 @@ const nodes = {
   },
   FragmentDefinition(node: FragmentDefinitionNode): string {
     let out = 'fragment ' + node.name.value;
-    if (node.variableDefinitions && node.variableDefinitions.length)
-      out += '(' + mapJoin(node.variableDefinitions, ', ', nodes.VariableDefinition) + ')';
     out += ' on ' + node.typeCondition.name.value;
     if (node.directives && node.directives.length)
       out += ' ' + mapJoin(node.directives, ' ', nodes.Directive);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,133 +1,191 @@
-import type { ASTNode } from './ast';
+import type {
+  ASTNode,
+  NameNode,
+  DocumentNode,
+  VariableNode,
+  SelectionSetNode,
+  FieldNode,
+  ArgumentNode,
+  FragmentSpreadNode,
+  InlineFragmentNode,
+  VariableDefinitionNode,
+  OperationDefinitionNode,
+  FragmentDefinitionNode,
+  IntValueNode,
+  FloatValueNode,
+  StringValueNode,
+  BooleanValueNode,
+  NullValueNode,
+  EnumValueNode,
+  ListValueNode,
+  ObjectValueNode,
+  ObjectFieldNode,
+  DirectiveNode,
+  NamedTypeNode,
+  ListTypeNode,
+  NonNullTypeNode,
+} from './ast';
 
-export function printString(string: string) {
+function printString(string: string) {
   return JSON.stringify(string);
 }
 
-export function printBlockString(string: string) {
+function printBlockString(string: string) {
   return '"""\n' + string.replace(/"""/g, '\\"""') + '\n"""';
 }
 
-const hasItems = <T>(array: ReadonlyArray<T> | undefined | null): array is ReadonlyArray<T> =>
-  !!(array && array.length);
-
 const MAX_LINE_LENGTH = 80;
 
-const nodes: {
-  [NodeT in ASTNode as NodeT['kind']]?: (node: NodeT) => string;
-} = {
-  OperationDefinition(node) {
+let INDENT = 0;
+
+const nodes = {
+  OperationDefinition(node: OperationDefinitionNode): string {
     if (
       node.operation === 'query' &&
       !node.name &&
-      !hasItems(node.variableDefinitions) &&
-      !hasItems(node.directives)
+      !(node.variableDefinitions && node.variableDefinitions.length) &&
+      !(node.directives && node.directives.length)
     ) {
-      return nodes.SelectionSet!(node.selectionSet);
+      return nodes.SelectionSet(node.selectionSet);
     }
     let out: string = node.operation;
     if (node.name) out += ' ' + node.name.value;
-    if (hasItems(node.variableDefinitions)) {
+    if (node.variableDefinitions && node.variableDefinitions.length) {
       if (!node.name) out += ' ';
-      out += '(' + node.variableDefinitions.map(nodes.VariableDefinition!).join(', ') + ')';
+      out += '(' + node.variableDefinitions.map(nodes.VariableDefinition).join(', ') + ')';
     }
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
     return out + ' ' + nodes.SelectionSet!(node.selectionSet);
   },
-  VariableDefinition(node) {
-    let out = nodes.Variable!(node.variable) + ': ' + print(node.type);
-    if (node.defaultValue) out += ' = ' + print(node.defaultValue);
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+  VariableDefinition(node: VariableDefinitionNode): string {
+    let out = nodes.Variable!(node.variable) + ': ' + _print(node.type);
+    if (node.defaultValue) out += ' = ' + _print(node.defaultValue);
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
     return out;
   },
-  Field(node) {
-    let out = (node.alias ? node.alias.value + ': ' : '') + node.name.value;
-    if (hasItems(node.arguments)) {
-      const args = node.arguments.map(nodes.Argument!);
-      const argsLine = out + '(' + args.join(', ') + ')';
-      out =
-        argsLine.length > MAX_LINE_LENGTH
-          ? out + '(\n  ' + args.join('\n').replace(/\n/g, '\n  ') + '\n)'
-          : argsLine;
+  Field(node: FieldNode): string {
+    let out = node.alias ? node.alias.value + ': ' + node.name.value : node.name.value;
+    if (node.arguments && node.arguments.length) {
+      const args = node.arguments.map(nodes.Argument);
+      const argsLine = '(' + args.join(', ') + ')';
+      if (out.length + argsLine.length > MAX_LINE_LENGTH) {
+        out +=
+          '(\n' +
+          '  '.repeat(++INDENT) +
+          args.join('\n' + '  '.repeat(INDENT)) +
+          '\n' +
+          '  '.repeat(--INDENT) +
+          ')';
+      } else {
+        out += argsLine;
+      }
     }
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
-    return node.selectionSet ? out + ' ' + nodes.SelectionSet!(node.selectionSet) : out;
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
+    if (node.selectionSet) out += ' ' + nodes.SelectionSet(node.selectionSet);
+    return out;
   },
-  StringValue(node) {
-    return node.block ? printBlockString(node.value) : printString(node.value);
+  StringValue(node: StringValueNode): string {
+    if (node.block) {
+      return printBlockString(node.value).replace(/\n/g, '\n' + '  '.repeat(INDENT + 1));
+    } else {
+      return printString(node.value);
+    }
   },
-  BooleanValue(node) {
+  BooleanValue(node: BooleanValueNode): string {
     return '' + node.value;
   },
-  NullValue(_node) {
+  NullValue(_node: NullValueNode): string {
     return 'null';
   },
-  IntValue(node) {
+  IntValue(node: IntValueNode): string {
     return node.value;
   },
-  FloatValue(node) {
+  FloatValue(node: FloatValueNode): string {
     return node.value;
   },
-  EnumValue(node) {
+  EnumValue(node: EnumValueNode): string {
     return node.value;
   },
-  Name(node) {
+  Name(node: NameNode): string {
     return node.value;
   },
-  Variable(node) {
+  Variable(node: VariableNode): string {
     return '$' + node.name.value;
   },
-  ListValue(node) {
-    return '[' + node.values.map(print).join(', ') + ']';
+  ListValue(node: ListValueNode): string {
+    return '[' + node.values.map(_print).join(', ') + ']';
   },
-  ObjectValue(node) {
-    return '{' + node.fields.map(nodes.ObjectField!).join(', ') + '}';
+  ObjectValue(node: ObjectValueNode): string {
+    return '{' + node.fields.map(nodes.ObjectField).join(', ') + '}';
   },
-  ObjectField(node) {
-    return node.name.value + ': ' + print(node.value);
+  ObjectField(node: ObjectFieldNode): string {
+    return node.name.value + ': ' + _print(node.value);
   },
-  Document(node) {
-    return hasItems(node.definitions) ? node.definitions.map(print).join('\n\n') : '';
+  Document(node: DocumentNode): string {
+    if (!node.definitions || !node.definitions.length) return '';
+    return node.definitions.map(_print).join('\n\n');
   },
-  SelectionSet(node) {
-    return '{\n  ' + node.selections.map(print).join('\n').replace(/\n/g, '\n  ') + '\n}';
+  SelectionSet(node: SelectionSetNode): string {
+    return (
+      '{\n' +
+      '  '.repeat(++INDENT) +
+      node.selections.map(_print).join('\n' + '  '.repeat(INDENT)) +
+      '\n' +
+      '  '.repeat(--INDENT) +
+      '}'
+    );
   },
-  Argument(node) {
-    return node.name.value + ': ' + print(node.value);
+  Argument(node: ArgumentNode): string {
+    return node.name.value + ': ' + _print(node.value);
   },
-  FragmentSpread(node) {
+  FragmentSpread(node: FragmentSpreadNode): string {
     let out = '...' + node.name.value;
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
     return out;
   },
-  InlineFragment(node) {
+  InlineFragment(node: InlineFragmentNode): string {
     let out = '...';
     if (node.typeCondition) out += ' on ' + node.typeCondition.name.value;
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
-    return out + ' ' + print(node.selectionSet);
-  },
-  FragmentDefinition(node) {
-    let out = 'fragment ' + node.name.value;
-    out += ' on ' + node.typeCondition.name.value;
-    if (hasItems(node.directives)) out += ' ' + node.directives.map(nodes.Directive!).join(' ');
-    return out + ' ' + print(node.selectionSet);
-  },
-  Directive(node) {
-    let out = '@' + node.name.value;
-    if (hasItems(node.arguments)) out += '(' + node.arguments.map(nodes.Argument!).join(', ') + ')';
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
+    out += ' ' + _print(node.selectionSet);
     return out;
   },
-  NamedType(node) {
+  FragmentDefinition(node: FragmentDefinitionNode): string {
+    let out = 'fragment ' + node.name.value;
+    if (node.variableDefinitions && node.variableDefinitions.length)
+      out += '(' + node.variableDefinitions.map(nodes.VariableDefinition).join(', ') + ')';
+    out += ' on ' + node.typeCondition.name.value;
+    if (node.directives && node.directives.length)
+      out += ' ' + node.directives.map(nodes.Directive).join(' ');
+    return out + ' ' + _print(node.selectionSet);
+  },
+  Directive(node: DirectiveNode): string {
+    let out = '@' + node.name.value;
+    if (node.arguments && node.arguments.length)
+      out += '(' + node.arguments.map(nodes.Argument).join(', ') + ')';
+    return out;
+  },
+  NamedType(node: NamedTypeNode): string {
     return node.name.value;
   },
-  ListType(node) {
-    return '[' + print(node.type) + ']';
+  ListType(node: ListTypeNode): string {
+    return '[' + _print(node.type) + ']';
   },
-  NonNullType(node) {
-    return print(node.type) + '!';
+  NonNullType(node: NonNullTypeNode): string {
+    return _print(node.type) + '!';
   },
-};
+} as const;
 
-export function print(node: ASTNode): string {
-  return nodes[node.kind] ? (nodes as any)[node.kind]!(node) : '';
+const _print = (node: ASTNode): string => nodes[node.kind](node);
+
+function print(node: ASTNode): string {
+  INDENT = 0;
+  return nodes[node.kind] ? nodes[node.kind](node) : '';
 }
+
+export { print, printString, printBlockString };

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -49,8 +49,8 @@ const nodes = {
     if (node.directives && node.directives.length)
       out += ' ' + node.directives.map(nodes.Directive).join(' ');
     return out !== 'query'
-      ? out + ' ' + nodes.SelectionSet!(node.selectionSet)
-      : nodes.SelectionSet!(node.selectionSet);
+      ? out + ' ' + nodes.SelectionSet(node.selectionSet)
+      : nodes.SelectionSet(node.selectionSet);
   },
   VariableDefinition(node: VariableDefinitionNode): string {
     let out = nodes.Variable!(node.variable) + ': ' + _print(node.type);
@@ -146,7 +146,7 @@ const nodes = {
     if (node.typeCondition) out += ' on ' + node.typeCondition.name.value;
     if (node.directives && node.directives.length)
       out += ' ' + node.directives.map(nodes.Directive).join(' ');
-    out += ' ' + _print(node.selectionSet);
+    out += ' ' + nodes.SelectionSet(node.selectionSet);
     return out;
   },
   FragmentDefinition(node: FragmentDefinitionNode): string {
@@ -156,7 +156,7 @@ const nodes = {
     out += ' on ' + node.typeCondition.name.value;
     if (node.directives && node.directives.length)
       out += ' ' + node.directives.map(nodes.Directive).join(' ');
-    return out + ' ' + _print(node.selectionSet);
+    return out + ' ' + nodes.SelectionSet(node.selectionSet);
   },
   Directive(node: DirectiveNode): string {
     let out = '@' + node.name.value;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -40,14 +40,6 @@ let INDENT = 0;
 
 const nodes = {
   OperationDefinition(node: OperationDefinitionNode): string {
-    if (
-      node.operation === 'query' &&
-      !node.name &&
-      !(node.variableDefinitions && node.variableDefinitions.length) &&
-      !(node.directives && node.directives.length)
-    ) {
-      return nodes.SelectionSet(node.selectionSet);
-    }
     let out: string = node.operation;
     if (node.name) out += ' ' + node.name.value;
     if (node.variableDefinitions && node.variableDefinitions.length) {
@@ -56,7 +48,9 @@ const nodes = {
     }
     if (node.directives && node.directives.length)
       out += ' ' + node.directives.map(nodes.Directive).join(' ');
-    return out + ' ' + nodes.SelectionSet!(node.selectionSet);
+    return out !== 'query'
+      ? out + ' ' + nodes.SelectionSet!(node.selectionSet)
+      : nodes.SelectionSet!(node.selectionSet);
   },
   VariableDefinition(node: VariableDefinitionNode): string {
     let out = nodes.Variable!(node.variable) + ': ' + _print(node.type);


### PR DESCRIPTION
## Set of changes

- **Unrelated:** Fix invalid type alias in `src/ast.ts`’ `StringValueNode`
- Add new indentation logic without `.replace`
- Replace `.map` + `.join` with `mapJoin` function
- Fix `nodes.SelectionSet` not being reused in some places

**Note:** The benchmarks fluctuate. Sometimes the old code can reach >100K Hz, sometimes it can't.

### Before

```
@0no-co/graphql.web  105,914.82  0.0088  0.2635  0.0094  0.0093  0.0115  0.0121  0.0858  ±0.32%    52958   fastest
```

### After

```
@0no-co/graphql.web  127,397.56  0.0070  0.4896  0.0078  0.0077  0.0092  0.0097  0.0761  ±0.34%    63699   fastest
```