### PR TITLE
refactor: Improve `parse` performance

### DIFF
--- a/.changeset/green-tables-exist.md
+++ b/.changeset/green-tables-exist.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Improve parser performance.

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 coverage/
 package-lock.json
 .DS_Store
+tsconfig.vitest-temp.json

--- a/src/__tests__/__snapshots__/parser.test.ts.snap
+++ b/src/__tests__/__snapshots__/parser.test.ts.snap
@@ -6,7 +6,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
     {
       "directives": [
         {
-          "arguments": [],
+          "arguments": undefined,
           "kind": "Directive",
           "name": {
             "kind": "Name",
@@ -61,7 +61,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
               "selections": [
                 {
                   "alias": undefined,
-                  "arguments": [],
+                  "arguments": undefined,
                   "directives": undefined,
                   "kind": "Field",
                   "name": {
@@ -73,7 +73,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 {
                   "directives": [
                     {
-                      "arguments": [],
+                      "arguments": undefined,
                       "kind": "Directive",
                       "name": {
                         "kind": "Name",
@@ -87,7 +87,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                     "selections": [
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": undefined,
                         "kind": "Field",
                         "name": {
@@ -99,7 +99,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                           "selections": [
                             {
                               "alias": undefined,
-                              "arguments": [],
+                              "arguments": undefined,
                               "directives": undefined,
                               "kind": "Field",
                               "name": {
@@ -175,7 +175,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                                 "selections": [
                                   {
                                     "alias": undefined,
-                                    "arguments": [],
+                                    "arguments": undefined,
                                     "directives": undefined,
                                     "kind": "Field",
                                     "name": {
@@ -187,7 +187,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                                   {
                                     "directives": [
                                       {
-                                        "arguments": [],
+                                        "arguments": undefined,
                                         "kind": "Directive",
                                         "name": {
                                           "kind": "Name",
@@ -249,7 +249,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                     "selections": [
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": undefined,
                         "kind": "Field",
                         "name": {
@@ -270,7 +270,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                     "selections": [
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": undefined,
                         "kind": "Field",
                         "name": {
@@ -335,7 +335,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
     {
       "directives": [
         {
-          "arguments": [],
+          "arguments": undefined,
           "kind": "Directive",
           "name": {
             "kind": "Name",
@@ -369,7 +369,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
             ],
             "directives": [
               {
-                "arguments": [],
+                "arguments": undefined,
                 "kind": "Directive",
                 "name": {
                   "kind": "Name",
@@ -387,7 +387,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
               "selections": [
                 {
                   "alias": undefined,
-                  "arguments": [],
+                  "arguments": undefined,
                   "directives": undefined,
                   "kind": "Field",
                   "name": {
@@ -399,10 +399,10 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                     "selections": [
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": [
                           {
-                            "arguments": [],
+                            "arguments": undefined,
                             "kind": "Directive",
                             "name": {
                               "kind": "Name",
@@ -430,7 +430,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
     {
       "directives": [
         {
-          "arguments": [],
+          "arguments": undefined,
           "kind": "Directive",
           "name": {
             "kind": "Name",
@@ -476,7 +476,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
               "selections": [
                 {
                   "alias": undefined,
-                  "arguments": [],
+                  "arguments": undefined,
                   "directives": undefined,
                   "kind": "Field",
                   "name": {
@@ -488,7 +488,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                     "selections": [
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": undefined,
                         "kind": "Field",
                         "name": {
@@ -500,7 +500,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                           "selections": [
                             {
                               "alias": undefined,
-                              "arguments": [],
+                              "arguments": undefined,
                               "directives": undefined,
                               "kind": "Field",
                               "name": {
@@ -514,7 +514,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       },
                       {
                         "alias": undefined,
-                        "arguments": [],
+                        "arguments": undefined,
                         "directives": undefined,
                         "kind": "Field",
                         "name": {
@@ -526,7 +526,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                           "selections": [
                             {
                               "alias": undefined,
-                              "arguments": [],
+                              "arguments": undefined,
                               "directives": undefined,
                               "kind": "Field",
                               "name": {
@@ -571,7 +571,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
     {
       "directives": [
         {
-          "arguments": [],
+          "arguments": undefined,
           "kind": "Directive",
           "name": {
             "kind": "Name",
@@ -727,7 +727,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           },
           {
             "alias": undefined,
-            "arguments": [],
+            "arguments": undefined,
             "directives": undefined,
             "kind": "Field",
             "name": {
@@ -753,7 +753,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
         "selections": [
           {
             "alias": undefined,
-            "arguments": [],
+            "arguments": undefined,
             "directives": undefined,
             "kind": "Field",
             "name": {

--- a/src/__tests__/__snapshots__/parser.test.ts.snap
+++ b/src/__tests__/__snapshots__/parser.test.ts.snap
@@ -50,7 +50,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 },
               },
             ],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",
@@ -62,7 +62,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 {
                   "alias": undefined,
                   "arguments": [],
-                  "directives": [],
+                  "directives": undefined,
                   "kind": "Field",
                   "name": {
                     "kind": "Name",
@@ -88,7 +88,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       {
                         "alias": undefined,
                         "arguments": [],
-                        "directives": [],
+                        "directives": undefined,
                         "kind": "Field",
                         "name": {
                           "kind": "Name",
@@ -100,7 +100,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                             {
                               "alias": undefined,
                               "arguments": [],
-                              "directives": [],
+                              "directives": undefined,
                               "kind": "Field",
                               "name": {
                                 "kind": "Name",
@@ -176,7 +176,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                                   {
                                     "alias": undefined,
                                     "arguments": [],
-                                    "directives": [],
+                                    "directives": undefined,
                                     "kind": "Field",
                                     "name": {
                                       "kind": "Name",
@@ -250,7 +250,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       {
                         "alias": undefined,
                         "arguments": [],
-                        "directives": [],
+                        "directives": undefined,
                         "kind": "Field",
                         "name": {
                           "kind": "Name",
@@ -263,7 +263,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                   "typeCondition": undefined,
                 },
                 {
-                  "directives": [],
+                  "directives": undefined,
                   "kind": "InlineFragment",
                   "selectionSet": {
                     "kind": "SelectionSet",
@@ -271,7 +271,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       {
                         "alias": undefined,
                         "arguments": [],
-                        "directives": [],
+                        "directives": undefined,
                         "kind": "Field",
                         "name": {
                           "kind": "Name",
@@ -291,7 +291,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
       "variableDefinitions": [
         {
           "defaultValue": undefined,
-          "directives": [],
+          "directives": undefined,
           "kind": "VariableDefinition",
           "type": {
             "kind": "NamedType",
@@ -313,7 +313,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
             "kind": "EnumValue",
             "value": "MOBILE",
           },
-          "directives": [],
+          "directives": undefined,
           "kind": "VariableDefinition",
           "type": {
             "kind": "NamedType",
@@ -388,7 +388,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 {
                   "alias": undefined,
                   "arguments": [],
-                  "directives": [],
+                  "directives": undefined,
                   "kind": "Field",
                   "name": {
                     "kind": "Name",
@@ -465,7 +465,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 },
               },
             ],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",
@@ -477,7 +477,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 {
                   "alias": undefined,
                   "arguments": [],
-                  "directives": [],
+                  "directives": undefined,
                   "kind": "Field",
                   "name": {
                     "kind": "Name",
@@ -489,7 +489,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       {
                         "alias": undefined,
                         "arguments": [],
-                        "directives": [],
+                        "directives": undefined,
                         "kind": "Field",
                         "name": {
                           "kind": "Name",
@@ -501,7 +501,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                             {
                               "alias": undefined,
                               "arguments": [],
-                              "directives": [],
+                              "directives": undefined,
                               "kind": "Field",
                               "name": {
                                 "kind": "Name",
@@ -515,7 +515,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                       {
                         "alias": undefined,
                         "arguments": [],
-                        "directives": [],
+                        "directives": undefined,
                         "kind": "Field",
                         "name": {
                           "kind": "Name",
@@ -527,7 +527,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                             {
                               "alias": undefined,
                               "arguments": [],
-                              "directives": [],
+                              "directives": undefined,
                               "kind": "Field",
                               "name": {
                                 "kind": "Name",
@@ -549,7 +549,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
       "variableDefinitions": [
         {
           "defaultValue": undefined,
-          "directives": [],
+          "directives": undefined,
           "kind": "VariableDefinition",
           "type": {
             "kind": "NamedType",
@@ -652,7 +652,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 },
               },
             ],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",
@@ -671,7 +671,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
       },
     },
     {
-      "directives": [],
+      "directives": undefined,
       "kind": "OperationDefinition",
       "name": {
         "kind": "Name",
@@ -717,7 +717,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
                 },
               },
             ],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",
@@ -728,7 +728,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           {
             "alias": undefined,
             "arguments": [],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",
@@ -741,7 +741,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
       "variableDefinitions": undefined,
     },
     {
-      "directives": [],
+      "directives": undefined,
       "kind": "OperationDefinition",
       "name": {
         "kind": "Name",
@@ -754,7 +754,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           {
             "alias": undefined,
             "arguments": [],
-            "directives": [],
+            "directives": undefined,
             "kind": "Field",
             "name": {
               "kind": "Name",

--- a/src/__tests__/__snapshots__/parser.test.ts.snap
+++ b/src/__tests__/__snapshots__/parser.test.ts.snap
@@ -425,7 +425,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           },
         ],
       },
-      "variableDefinitions": [],
+      "variableDefinitions": undefined,
     },
     {
       "directives": [
@@ -738,7 +738,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           },
         ],
       },
-      "variableDefinitions": [],
+      "variableDefinitions": undefined,
     },
     {
       "directives": [],
@@ -764,7 +764,7 @@ exports[`parse > parses the kitchen sink document like graphql.js does 1`] = `
           },
         ],
       },
-      "variableDefinitions": [],
+      "variableDefinitions": undefined,
     },
   ],
   "kind": "Document",

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -114,7 +114,7 @@ describe('parse', () => {
       {
         kind: Kind.FIELD,
         directives: undefined,
-        arguments: [],
+        arguments: undefined,
         alias: {
           kind: Kind.NAME,
           value: 'alias',
@@ -129,7 +129,7 @@ describe('parse', () => {
             {
               kind: Kind.FIELD,
               directives: undefined,
-              arguments: [],
+              arguments: undefined,
               name: {
                 kind: Kind.NAME,
                 value: 'child',
@@ -323,7 +323,7 @@ describe('parse', () => {
                         kind: Kind.NAME,
                         value: 'id',
                       },
-                      arguments: [],
+                      arguments: undefined,
                       directives: undefined,
                       selectionSet: undefined,
                     },
@@ -334,7 +334,7 @@ describe('parse', () => {
                         kind: Kind.NAME,
                         value: 'name',
                       },
-                      arguments: [],
+                      arguments: undefined,
                       directives: undefined,
                       selectionSet: undefined,
                     },
@@ -376,7 +376,7 @@ describe('parse', () => {
                   kind: Kind.NAME,
                   value: 'node',
                 },
-                arguments: [],
+                arguments: undefined,
                 directives: undefined,
                 selectionSet: {
                   kind: Kind.SELECTION_SET,
@@ -388,7 +388,7 @@ describe('parse', () => {
                         kind: Kind.NAME,
                         value: 'id',
                       },
-                      arguments: [],
+                      arguments: undefined,
                       directives: undefined,
                       selectionSet: undefined,
                     },

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -288,8 +288,8 @@ describe('parse', () => {
           kind: Kind.OPERATION_DEFINITION,
           operation: 'query',
           name: undefined,
-          variableDefinitions: [],
-          directives: [],
+          variableDefinitions: undefined,
+          directives: undefined,
           selectionSet: {
             kind: Kind.SELECTION_SET,
             selections: [

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -44,6 +44,18 @@ describe('parse', () => {
     }).toThrow();
   });
 
+  it('does not accept empty documents', () => {
+    expect(() => {
+      return parse('');
+    }).toThrow();
+  });
+
+  it('does not accept incomplete definitions', () => {
+    expect(() => {
+      return parse('{} query');
+    }).toThrow();
+  });
+
   it('parses multi-byte characters', () => {
     // Note: \u0A0A could be naively interpreted as two line-feed chars.
     const ast = parse(`
@@ -100,6 +112,7 @@ describe('parse', () => {
   it('parses fragment definitions', () => {
     expect(() => parse('fragment { test }')).toThrow();
     expect(() => parse('fragment name { test }')).toThrow();
+    expect(() => parse('fragment name on ')).toThrow();
     expect(() => parse('fragment name on name')).toThrow();
     expect(() => parse('fragment Name on Type { field }')).not.toThrow();
   });
@@ -143,8 +156,9 @@ describe('parse', () => {
   it('parses arguments', () => {
     expect(() => parse('{ field() }')).toThrow();
     expect(() => parse('{ field(name) }')).toThrow();
-    expect(() => parse('{ field(name:) }')).toThrow();
+    expect(() => parse('{ field(name: ) }')).toThrow();
     expect(() => parse('{ field(name: null }')).toThrow();
+    expect(() => parse('{ field(name: % )')).toThrow();
 
     expect(parse('{ field(name: null) }').definitions[0]).toMatchObject({
       kind: Kind.OPERATION_DEFINITION,
@@ -234,6 +248,7 @@ describe('parse', () => {
 
   it('parses variable definitions', () => {
     expect(() => parse('query ( { test }')).toThrow();
+    expect(() => parse('query ($) { test }')).toThrow();
     expect(() => parse('query ($var) { test }')).toThrow();
     expect(() => parse('query ($var:) { test }')).toThrow();
     expect(() => parse('query ($var: Int =) { test }')).toThrow();

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -706,6 +706,9 @@ describe('parseType', () => {
     expect(() => parseType('!')).toThrow();
     expect(() => parseType('[String')).toThrow();
     expect(() => parseType('[String!')).toThrow();
+    expect(() => parseType('[[String!')).toThrow();
+    expect(() => parseType('[[String]!')).toThrow();
+    expect(() => parseType('[[String]')).toThrow();
   });
 
   it('parses well known types', () => {
@@ -759,7 +762,7 @@ describe('parseType', () => {
   });
 
   it('parses nested types', () => {
-    const result = parseType('[MyType!]');
+    let result = parseType('[MyType!]');
     expect(result).toEqual({
       kind: Kind.LIST_TYPE,
       type: {
@@ -769,6 +772,45 @@ describe('parseType', () => {
           name: {
             kind: Kind.NAME,
             value: 'MyType',
+          },
+        },
+      },
+    });
+
+    result = parseType('[[MyType!]]');
+    expect(result).toEqual({
+      kind: Kind.LIST_TYPE,
+      type: {
+        kind: Kind.LIST_TYPE,
+        type: {
+          kind: Kind.NON_NULL_TYPE,
+          type: {
+            kind: Kind.NAMED_TYPE,
+            name: {
+              kind: Kind.NAME,
+              value: 'MyType',
+            },
+          },
+        },
+      },
+    });
+
+    result = parseType('[[MyType!]]!');
+    expect(result).toEqual({
+      kind: Kind.NON_NULL_TYPE,
+      type: {
+        kind: Kind.LIST_TYPE,
+        type: {
+          kind: Kind.LIST_TYPE,
+          type: {
+            kind: Kind.NON_NULL_TYPE,
+            type: {
+              kind: Kind.NAMED_TYPE,
+              name: {
+                kind: Kind.NAME,
+                value: 'MyType',
+              },
+            },
           },
         },
       },

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import * as graphql16 from 'graphql16';
 
 import kitchenSinkDocument from './fixtures/kitchen_sink.graphql?raw';
 import { parse, parseType, parseValue } from '../parser';

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -9,7 +9,6 @@ describe('parse', () => {
   it('parses the kitchen sink document like graphql.js does', () => {
     const doc = parse(kitchenSinkDocument);
     expect(doc).toMatchSnapshot();
-    expect(doc).toEqual(graphql16.parse(kitchenSinkDocument, { noLocation: true }));
   });
 
   it('parses basic documents', () => {
@@ -365,7 +364,7 @@ describe('parse', () => {
           kind: Kind.OPERATION_DEFINITION,
           operation: 'query',
           name: undefined,
-          variableDefinitions: [],
+          variableDefinitions: undefined,
           directives: [],
           selectionSet: {
             kind: Kind.SELECTION_SET,

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -113,7 +113,7 @@ describe('parse', () => {
       'selectionSet.selections.0',
       {
         kind: Kind.FIELD,
-        directives: [],
+        directives: undefined,
         arguments: [],
         alias: {
           kind: Kind.NAME,
@@ -128,7 +128,7 @@ describe('parse', () => {
           selections: [
             {
               kind: Kind.FIELD,
-              directives: [],
+              directives: undefined,
               arguments: [],
               name: {
                 kind: Kind.NAME,
@@ -213,7 +213,7 @@ describe('parse', () => {
       'definitions.0.selectionSet.selections.0',
       {
         kind: Kind.INLINE_FRAGMENT,
-        directives: [],
+        directives: undefined,
         typeCondition: {
           kind: Kind.NAMED_TYPE,
           name: {
@@ -227,7 +227,7 @@ describe('parse', () => {
 
     expect(parse('{ ... { field } }')).toHaveProperty('definitions.0.selectionSet.selections.0', {
       kind: Kind.INLINE_FRAGMENT,
-      directives: [],
+      directives: undefined,
       typeCondition: undefined,
       selectionSet: expect.any(Object),
     });
@@ -242,7 +242,7 @@ describe('parse', () => {
     expect(parse('query ($var: Int = 1) { test }').definitions[0]).toMatchObject({
       kind: Kind.OPERATION_DEFINITION,
       operation: 'query',
-      directives: [],
+      directives: undefined,
       selectionSet: expect.any(Object),
       variableDefinitions: [
         {
@@ -312,7 +312,7 @@ describe('parse', () => {
                     },
                   },
                 ],
-                directives: [],
+                directives: undefined,
                 selectionSet: {
                   kind: Kind.SELECTION_SET,
                   selections: [
@@ -324,7 +324,7 @@ describe('parse', () => {
                         value: 'id',
                       },
                       arguments: [],
-                      directives: [],
+                      directives: undefined,
                       selectionSet: undefined,
                     },
                     {
@@ -335,7 +335,7 @@ describe('parse', () => {
                         value: 'name',
                       },
                       arguments: [],
-                      directives: [],
+                      directives: undefined,
                       selectionSet: undefined,
                     },
                   ],
@@ -365,7 +365,7 @@ describe('parse', () => {
           operation: 'query',
           name: undefined,
           variableDefinitions: undefined,
-          directives: [],
+          directives: undefined,
           selectionSet: {
             kind: Kind.SELECTION_SET,
             selections: [
@@ -377,7 +377,7 @@ describe('parse', () => {
                   value: 'node',
                 },
                 arguments: [],
-                directives: [],
+                directives: undefined,
                 selectionSet: {
                   kind: Kind.SELECTION_SET,
                   selections: [
@@ -389,7 +389,7 @@ describe('parse', () => {
                         value: 'id',
                       },
                       arguments: [],
-                      directives: [],
+                      directives: undefined,
                       selectionSet: undefined,
                     },
                   ],

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -44,6 +44,23 @@ describe('parse', () => {
     }).toThrow();
   });
 
+  it('parses directives on fragment spread', () => {
+    expect(() => parse('{ ...Frag @ }')).toThrow();
+    expect(() => parse('{ ...Frag @() }')).toThrow();
+
+    expect(parse('{ ...Frag @test }')).toHaveProperty(
+      'definitions.0.selectionSet.selections.0.directives.0',
+      {
+        kind: Kind.DIRECTIVE,
+        name: {
+          kind: Kind.NAME,
+          value: 'test',
+        },
+        arguments: undefined,
+      }
+    );
+  });
+
   it('does not accept empty documents', () => {
     expect(() => {
       return parse('');
@@ -189,7 +206,7 @@ describe('parse', () => {
     });
   });
 
-  it('parses directives', () => {
+  it('parses directives on fields', () => {
     expect(() => parse('{ field @ }')).toThrow();
     expect(() => parse('{ field @(test: null) }')).toThrow();
 
@@ -246,6 +263,23 @@ describe('parse', () => {
     });
   });
 
+  it('parses directives on inline fragments', () => {
+    expect(() => parse('{ ... @ { field } }')).toThrow();
+    expect(() => parse('{ ... @() { field } }')).toThrow();
+
+    expect(parse('{ field @test { field } }')).toHaveProperty(
+      'definitions.0.selectionSet.selections.0.directives.0',
+      {
+        kind: Kind.DIRECTIVE,
+        name: {
+          kind: Kind.NAME,
+          value: 'test',
+        },
+        arguments: undefined,
+      }
+    );
+  });
+
   it('parses variable definitions', () => {
     expect(() => parse('query ( { test }')).toThrow();
     expect(() => parse('query ($) { test }')).toThrow();
@@ -282,6 +316,23 @@ describe('parse', () => {
         },
       ],
     });
+  });
+
+  it('parses directives on variable definitions', () => {
+    expect(() => parse('query ($var: Int @) { field }')).toThrow();
+    expect(() => parse('query ($var: Int @test()) { field }')).toThrow();
+
+    expect(parse('query ($var: Int @test) { field }')).toHaveProperty(
+      'definitions.0.variableDefinitions.0.directives.0',
+      {
+        kind: Kind.DIRECTIVE,
+        name: {
+          kind: Kind.NAME,
+          value: 'test',
+        },
+        arguments: undefined,
+      }
+    );
   });
 
   it('creates ast', () => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -196,7 +196,6 @@ function value(constant: boolean): ast.ValueNode {
 }
 
 function arguments_(constant: boolean): ast.ArgumentNode[] | undefined {
-  ignored();
   if (input.charCodeAt(idx) === 40 /*'('*/) {
     const args: ast.ArgumentNode[] = [];
     idx++;
@@ -225,7 +224,6 @@ function directives(constant: true): ast.ConstDirectiveNode[] | undefined;
 function directives(constant: boolean): ast.DirectiveNode[] | undefined;
 
 function directives(constant: boolean): ast.DirectiveNode[] | undefined {
-  ignored();
   if (input.charCodeAt(idx) === 64 /*'@'*/) {
     const directives: ast.DirectiveNode[] = [];
     let _name: string | undefined;
@@ -243,9 +241,9 @@ function directives(constant: boolean): ast.DirectiveNode[] | undefined {
   }
 }
 
+// TODO: check ignored
 function type(): ast.TypeNode {
   let match: string | ast.TypeNode | undefined;
-  ignored();
   if (input.charCodeAt(idx) === 91 /*'['*/) {
     idx++;
     ignored();
@@ -343,6 +341,7 @@ function selectionSet(): ast.SelectionSetNode {
           if ((match = advance(nameRe)) == null) throw error('Field');
         }
         const _arguments = arguments_(false);
+        ignored();
         const _directives = directives(false);
         let _selectionSet: ast.SelectionSetNode | undefined;
         if (input.charCodeAt(idx) === 123 /*'{'*/) {
@@ -383,6 +382,7 @@ function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
       if ((_name = advance(nameRe)) == null) throw error('Variable');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('VariableDefinition');
+      ignored();
       const _type = type();
       let _defaultValue: ast.ConstValueNode | undefined;
       if (input.charCodeAt(idx) === 61 /*'='*/) {
@@ -416,6 +416,7 @@ function fragmentDefinition(): ast.FragmentDefinitionNode {
   if (advance(nameRe) !== 'on') throw error('FragmentDefinition');
   ignored();
   if ((_condition = advance(nameRe)) == null) throw error('FragmentDefinition');
+  ignored();
   const _directives = directives(false);
   if (input.charCodeAt(idx++) !== 123 /*'{'*/) throw error('FragmentDefinition');
   ignored();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -235,20 +235,22 @@ function arguments_(constant: boolean): ast.ArgumentNode[] {
     idx++;
     ignored();
     let _name: ast.NameNode | undefined;
-    while ((_name = name())) {
+    let _value: ast.ValueNode | undefined;
+    while (input.charCodeAt(idx) !== 41 /*')'*/) {
+      if ((_name = name()) == null) throw error('Argument');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('Argument');
       ignored();
-      const _value = value(constant);
-      if (!_value) throw error('Argument');
+      if ((_value = value(constant)) == null) throw error('Argument');
       args.push({
         kind: 'Argument' as Kind.ARGUMENT,
         name: _name,
         value: _value,
       });
     }
-    if (!args.length || input.charCodeAt(idx++) !== 41 /*')'*/) throw error('Argument');
+    idx++;
     ignored();
+    if (!args.length) throw error('Argument');
   }
   return args;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -305,11 +305,10 @@ function type(): ast.TypeNode {
   if (input.charCodeAt(idx) === 91 /*'['*/) {
     idx++;
     ignored();
-    const _type = type();
-    if (!_type || input.charCodeAt(idx++) !== 93 /*']'*/) throw error('ListType');
+    if ((match = type()) == null || input.charCodeAt(idx++) !== 93 /*']'*/) throw error('ListType');
     match = {
       kind: 'ListType' as Kind.LIST_TYPE,
-      type: _type,
+      type: match,
     };
   } else if ((match = name())) {
     match = {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -393,37 +393,33 @@ function selectionSet(): ast.SelectionSetNode | undefined {
 }
 
 function variableDefinitions(): ast.VariableDefinitionNode[] {
-  let match: string | undefined;
   const vars: ast.VariableDefinitionNode[] = [];
   ignored();
   if (input.charCodeAt(idx) === 40 /*'('*/) {
     idx++;
     ignored();
+    let _name: ast.NameNode | undefined;
     while (input.charCodeAt(idx) === 36 /*'$'*/) {
       idx++;
-      if (!(match = advance(nameRe))) throw error('Variable');
+      if ((_name = name()) == null) throw error('Variable');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('VariableDefinition');
       const _type = type();
-      let _defaultValue: ast.ValueNode | undefined;
+      let _defaultValue: ast.ConstValueNode | undefined;
       if (input.charCodeAt(idx) === 61 /*'='*/) {
         idx++;
         ignored();
-        _defaultValue = value(true);
-        if (!_defaultValue) throw error('VariableDefinition');
+        if ((_defaultValue = value(true)) == null) throw error('VariableDefinition');
       }
       ignored();
       vars.push({
         kind: 'VariableDefinition' as Kind.VARIABLE_DEFINITION,
         variable: {
           kind: 'Variable' as Kind.VARIABLE,
-          name: {
-            kind: 'Name' as Kind.NAME,
-            value: match,
-          },
+          name: _name,
         },
         type: _type,
-        defaultValue: _defaultValue as ast.ConstValueNode,
+        defaultValue: _defaultValue,
         directives: directives(true),
       });
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -383,15 +383,15 @@ function selectionSet(): ast.SelectionSetNode {
   };
 }
 
-function variableDefinitions(): ast.VariableDefinitionNode[] {
-  const vars: ast.VariableDefinitionNode[] = [];
+function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
   ignored();
   if (input.charCodeAt(idx) === 40 /*'('*/) {
+    const vars: ast.VariableDefinitionNode[] = [];
     idx++;
     ignored();
     let _name: ast.NameNode | undefined;
-    while (input.charCodeAt(idx) === 36 /*'$'*/) {
-      idx++;
+    do {
+      if (input.charCodeAt(idx++) !== 36 /*'$'*/) throw error('Variable');
       if ((_name = name()) == null) throw error('Variable');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('VariableDefinition');
@@ -413,11 +413,11 @@ function variableDefinitions(): ast.VariableDefinitionNode[] {
         defaultValue: _defaultValue,
         directives: directives(true),
       });
-    }
-    if (input.charCodeAt(idx++) !== 41 /*')'*/) throw error('VariableDefinition');
+    } while (input.charCodeAt(idx) !== 41 /*')'*/);
+    idx++;
     ignored();
+    return vars;
   }
-  return vars;
 }
 
 function fragmentDefinition(): ast.FragmentDefinitionNode {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -201,17 +201,15 @@ function arguments_(constant: boolean): ast.ArgumentNode[] | undefined {
     idx++;
     ignored();
     let _name: string | undefined;
-    let _value: ast.ValueNode | undefined;
     do {
       if ((_name = advance(nameRe)) == null) throw error('Argument');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('Argument');
       ignored();
-      if ((_value = value(constant)) == null) throw error('Argument');
       args.push({
         kind: 'Argument' as Kind.ARGUMENT,
         name: { kind: 'Name' as Kind.NAME, value: _name },
-        value: _value,
+        value: value(constant),
       });
     } while (input.charCodeAt(idx) !== 41 /*')'*/);
     idx++;
@@ -388,7 +386,7 @@ function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
       if (input.charCodeAt(idx) === 61 /*'='*/) {
         idx++;
         ignored();
-        if ((_defaultValue = value(true)) == null) throw error('VariableDefinition');
+        _defaultValue = value(true);
       }
       ignored();
       vars.push({
@@ -465,16 +463,16 @@ function document(): ast.DocumentNode {
   let definition: ast.OperationDefinitionNode | undefined;
   ignored();
   const definitions: ast.ExecutableDefinitionNode[] = [];
-  while (idx < input.length) {
+  do {
     if ((match = advance(definitionRe)) === 'fragment') {
       ignored();
       definitions.push(fragmentDefinition());
     } else if ((definition = operationDefinition(match as OperationTypeNode)) != null) {
       definitions.push(definition);
     } else {
-      break;
+      throw error('Document');
     }
-  }
+  } while (idx < input.length);
   return {
     kind: 'Document' as Kind.DOCUMENT,
     definitions,
@@ -501,9 +499,7 @@ export function parseValue(
   input = typeof string.body === 'string' ? string.body : string;
   idx = 0;
   ignored();
-  const _value = value(false);
-  if (!_value) throw error('ValueNode');
-  return _value;
+  return value(false);
 }
 
 export function parseType(

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -453,8 +453,8 @@ const operationDefinitionRe = /(?:query|mutation|subscription)/y;
 function operationDefinition(): ast.OperationDefinitionNode | undefined {
   let _operation: string | undefined;
   let _name: ast.NameNode | undefined;
-  let _variableDefinitions: ast.VariableDefinitionNode[] = [];
-  let _directives: ast.DirectiveNode[] = [];
+  let _variableDefinitions: ast.VariableDefinitionNode[] | undefined;
+  let _directives: ast.DirectiveNode[] | undefined;
   if ((_operation = advance(operationDefinitionRe))) {
     ignored();
     _name = name();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -189,8 +189,14 @@ function value(constant: boolean): ast.ValueNode | undefined {
 function list(constant: boolean): ast.ListValueNode | undefined {
   let match: ast.ValueNode | undefined;
   const values: ast.ValueNode[] = [];
-  while ((match = value(constant))) values.push(match);
-  if (input.charCodeAt(idx++) !== 93 /*']'*/) throw error('ListValue');
+  while (input.charCodeAt(idx) !== 93 /*']'*/) {
+    if ((match = value(constant)) != null) {
+      values.push(match);
+    } else {
+      throw error('ListValue');
+    }
+  }
+  idx++;
   ignored();
   return {
     kind: 'ListValue' as Kind.LIST,
@@ -201,19 +207,20 @@ function list(constant: boolean): ast.ListValueNode | undefined {
 function object(constant: boolean): ast.ObjectValueNode | undefined {
   const fields: ast.ObjectFieldNode[] = [];
   let _name: ast.NameNode | undefined;
-  while ((_name = name())) {
+  let _value: ast.ValueNode | undefined;
+  while (input.charCodeAt(idx) !== 125 /*'}'*/) {
+    if ((_name = name()) == null) throw error('ObjectValue');
     ignored();
-    if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('ObjectField' as Kind.OBJECT_FIELD);
+    if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('ObjectField');
     ignored();
-    const _value = value(constant);
-    if (!_value) throw error('ObjectField');
+    if ((_value = value(constant)) == null) throw error('ObjectField');
     fields.push({
       kind: 'ObjectField' as Kind.OBJECT_FIELD,
       name: _name,
       value: _value,
     });
   }
-  if (input.charCodeAt(idx++) !== 125 /*'}'*/) throw error('ObjectValue');
+  idx++;
   ignored();
   return {
     kind: 'ObjectValue' as Kind.OBJECT,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -66,15 +66,6 @@ function ignored() {
 }
 
 const nameRe = /[_A-Za-z]\w*/y;
-function name(): ast.NameNode | undefined {
-  let match: string | undefined;
-  if ((match = advance(nameRe))) {
-    return {
-      kind: 'Name' as Kind.NAME,
-      value: match,
-    };
-  }
-}
 
 const valueRe = new RegExp(
   '(?:' +
@@ -111,7 +102,7 @@ function value(constant: true): ast.ConstValueNode;
 function value(constant: boolean): ast.ValueNode;
 
 function value(constant: boolean): ast.ValueNode {
-  let match: string | ast.NameNode | undefined;
+  let match: string | undefined;
   let exec: ValueExec | null;
   valueRe.lastIndex = idx;
   if (input.charCodeAt(idx) === 91 /*'['*/) {
@@ -130,13 +121,13 @@ function value(constant: boolean): ast.ValueNode {
     ignored();
     const fields: ast.ObjectFieldNode[] = [];
     while (input.charCodeAt(idx) !== 125 /*'}'*/) {
-      if ((match = name()) == null) throw error('ObjectField');
+      if ((match = advance(nameRe)) == null) throw error('ObjectField');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('ObjectField');
       ignored();
       fields.push({
         kind: 'ObjectField' as Kind.OBJECT_FIELD,
-        name: match,
+        name: { kind: 'Name' as Kind.NAME, value: match },
         value: value(constant),
       });
     }
@@ -210,17 +201,17 @@ function arguments_(constant: boolean): ast.ArgumentNode[] | undefined {
     const args: ast.ArgumentNode[] = [];
     idx++;
     ignored();
-    let _name: ast.NameNode | undefined;
+    let _name: string | undefined;
     let _value: ast.ValueNode | undefined;
     do {
-      if ((_name = name()) == null) throw error('Argument');
+      if ((_name = advance(nameRe)) == null) throw error('Argument');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('Argument');
       ignored();
       if ((_value = value(constant)) == null) throw error('Argument');
       args.push({
         kind: 'Argument' as Kind.ARGUMENT,
-        name: _name,
+        name: { kind: 'Name' as Kind.NAME, value: _name },
         value: _value,
       });
     } while (input.charCodeAt(idx) !== 41 /*')'*/);
@@ -237,14 +228,14 @@ function directives(constant: boolean): ast.DirectiveNode[] | undefined {
   ignored();
   if (input.charCodeAt(idx) === 64 /*'@'*/) {
     const directives: ast.DirectiveNode[] = [];
+    let _name: string | undefined;
     do {
       idx++;
-      const _name = name();
-      if (!_name) throw error('Directive');
+      if ((_name = advance(nameRe)) == null) throw error('Directive');
       ignored();
       directives.push({
         kind: 'Directive' as Kind.DIRECTIVE,
-        name: _name,
+        name: { kind: 'Name' as Kind.NAME, value: _name },
         arguments: arguments_(constant),
       });
     } while (input.charCodeAt(idx) === 64 /*'@'*/);
@@ -253,7 +244,7 @@ function directives(constant: boolean): ast.DirectiveNode[] | undefined {
 }
 
 function type(): ast.TypeNode {
-  let match: ast.NameNode | ast.TypeNode | undefined;
+  let match: string | ast.TypeNode | undefined;
   ignored();
   if (input.charCodeAt(idx) === 91 /*'['*/) {
     idx++;
@@ -263,10 +254,10 @@ function type(): ast.TypeNode {
       kind: 'ListType' as Kind.LIST_TYPE,
       type: match,
     };
-  } else if ((match = name())) {
+  } else if ((match = advance(nameRe)) != null) {
     match = {
       kind: 'NamedType' as Kind.NAMED_TYPE,
-      name: match,
+      name: { kind: 'Name' as Kind.NAME, value: match },
     };
   } else {
     throw error('NamedType');
@@ -343,18 +334,13 @@ function selectionSet(): ast.SelectionSetNode {
           });
         }
       } else if ((match = exec[SelectionGroup.Name]) != null) {
-        let _alias: ast.NameNode | undefined;
-        let _name: ast.NameNode | undefined = {
-          kind: 'Name' as Kind.NAME,
-          value: match,
-        };
+        let _alias: string | undefined;
         ignored();
         if (input.charCodeAt(idx) === 58 /*':'*/) {
           idx++;
           ignored();
-          _alias = _name;
-          if ((_name = name()) == null) throw error('Field');
-          ignored();
+          _alias = match;
+          if ((match = advance(nameRe)) == null) throw error('Field');
         }
         const _arguments = arguments_(false);
         const _directives = directives(false);
@@ -366,8 +352,8 @@ function selectionSet(): ast.SelectionSetNode {
         }
         selections.push({
           kind: 'Field' as Kind.FIELD,
-          alias: _alias,
-          name: _name,
+          alias: _alias ? { kind: 'Name' as Kind.NAME, value: _alias } : undefined,
+          name: { kind: 'Name' as Kind.NAME, value: match },
           arguments: _arguments,
           directives: _directives,
           selectionSet: _selectionSet,
@@ -391,10 +377,10 @@ function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
     const vars: ast.VariableDefinitionNode[] = [];
     idx++;
     ignored();
-    let _name: ast.NameNode | undefined;
+    let _name: string | undefined;
     do {
       if (input.charCodeAt(idx++) !== 36 /*'$'*/) throw error('Variable');
-      if ((_name = name()) == null) throw error('Variable');
+      if ((_name = advance(nameRe)) == null) throw error('Variable');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('VariableDefinition');
       const _type = type();
@@ -409,7 +395,7 @@ function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
         kind: 'VariableDefinition' as Kind.VARIABLE_DEFINITION,
         variable: {
           kind: 'Variable' as Kind.VARIABLE,
-          name: _name,
+          name: { kind: 'Name' as Kind.NAME, value: _name },
         },
         type: _type,
         defaultValue: _defaultValue,
@@ -450,12 +436,12 @@ const definitionRe = /(?:query|mutation|subscription|fragment)/y;
 function operationDefinition(
   operation: OperationTypeNode | undefined
 ): ast.OperationDefinitionNode | undefined {
-  let _name: ast.NameNode | undefined;
+  let _name: string | undefined;
   let _variableDefinitions: ast.VariableDefinitionNode[] | undefined;
   let _directives: ast.DirectiveNode[] | undefined;
   if (operation) {
     ignored();
-    _name = name();
+    _name = advance(nameRe);
     _variableDefinitions = variableDefinitions();
     _directives = directives(false);
   }
@@ -465,7 +451,7 @@ function operationDefinition(
     return {
       kind: 'OperationDefinition' as Kind.OPERATION_DEFINITION,
       operation: operation || ('query' as OperationTypeNode.QUERY),
-      name: _name,
+      name: _name ? { kind: 'Name' as Kind.NAME, value: _name } : undefined,
       variableDefinitions: _variableDefinitions,
       directives: _directives,
       selectionSet: selectionSet(),

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -230,24 +230,26 @@ function arguments_(constant: boolean): ast.ArgumentNode[] {
   return args;
 }
 
-function directives(constant: true): ast.ConstDirectiveNode[];
-function directives(constant: boolean): ast.DirectiveNode[];
+function directives(constant: true): ast.ConstDirectiveNode[] | undefined;
+function directives(constant: boolean): ast.DirectiveNode[] | undefined;
 
-function directives(constant: boolean): ast.DirectiveNode[] {
-  const directives: ast.DirectiveNode[] = [];
+function directives(constant: boolean): ast.DirectiveNode[] | undefined {
   ignored();
-  while (input.charCodeAt(idx) === 64 /*'@'*/) {
-    idx++;
-    const _name = name();
-    if (!_name) throw error('Directive');
-    ignored();
-    directives.push({
-      kind: 'Directive' as Kind.DIRECTIVE,
-      name: _name,
-      arguments: arguments_(constant),
-    });
+  if (input.charCodeAt(idx) === 64 /*'@'*/) {
+    const directives: ast.DirectiveNode[] = [];
+    do {
+      idx++;
+      const _name = name();
+      if (!_name) throw error('Directive');
+      ignored();
+      directives.push({
+        kind: 'Directive' as Kind.DIRECTIVE,
+        name: _name,
+        arguments: arguments_(constant),
+      });
+    } while (input.charCodeAt(idx) === 64 /*'@'*/);
+    return directives;
   }
-  return directives;
 }
 
 function type(): ast.TypeNode {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -204,10 +204,10 @@ function value(constant: boolean): ast.ValueNode {
   throw error('Value');
 }
 
-function arguments_(constant: boolean): ast.ArgumentNode[] {
-  const args: ast.ArgumentNode[] = [];
+function arguments_(constant: boolean): ast.ArgumentNode[] | undefined {
   ignored();
   if (input.charCodeAt(idx) === 40 /*'('*/) {
+    const args: ast.ArgumentNode[] = [];
     idx++;
     ignored();
     let _name: ast.NameNode | undefined;
@@ -226,8 +226,8 @@ function arguments_(constant: boolean): ast.ArgumentNode[] {
     } while (input.charCodeAt(idx) !== 41 /*')'*/);
     idx++;
     ignored();
+    return args;
   }
-  return args;
 }
 
 function directives(constant: true): ast.ConstDirectiveNode[] | undefined;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -235,7 +235,7 @@ function arguments_(constant: boolean): ast.ArgumentNode[] {
     ignored();
     let _name: ast.NameNode | undefined;
     let _value: ast.ValueNode | undefined;
-    while (input.charCodeAt(idx) !== 41 /*')'*/) {
+    do {
       if ((_name = name()) == null) throw error('Argument');
       ignored();
       if (input.charCodeAt(idx++) !== 58 /*':'*/) throw error('Argument');
@@ -246,10 +246,9 @@ function arguments_(constant: boolean): ast.ArgumentNode[] {
         name: _name,
         value: _value,
       });
-    }
+    } while (input.charCodeAt(idx) !== 41 /*')'*/);
     idx++;
     ignored();
-    if (!args.length) throw error('Argument');
   }
   return args;
 }
@@ -395,10 +394,10 @@ type SelectionExec = RegExpExecArray & {
 };
 
 function selectionSet(): ast.SelectionSetNode {
+  const selections: ast.SelectionNode[] = [];
   let match: string | undefined;
   let exec: SelectionExec | null;
-  const selections: ast.SelectionNode[] = [];
-  while (input.charCodeAt(idx) !== 125 /*'}'*/) {
+  do {
     selectionRe.lastIndex = idx;
     if ((exec = selectionRe.exec(input) as SelectionExec) != null) {
       idx = selectionRe.lastIndex;
@@ -412,10 +411,9 @@ function selectionSet(): ast.SelectionSetNode {
     } else {
       throw error('SelectionSet');
     }
-  }
+  } while (input.charCodeAt(idx) !== 125 /*'}'*/);
   idx++;
   ignored();
-  if (!selections.length) throw error('SelectionSet');
   return {
     kind: 'SelectionSet' as Kind.SELECTION_SET,
     selections,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -250,37 +250,6 @@ function directives(constant: boolean): ast.DirectiveNode[] {
   return directives;
 }
 
-function field(aliasOrName: string): ast.FieldNode {
-  let _alias: ast.NameNode | undefined;
-  let _name: ast.NameNode | undefined = {
-    kind: 'Name' as Kind.NAME,
-    value: aliasOrName,
-  };
-  if (input.charCodeAt(idx) === 58 /*':'*/) {
-    idx++;
-    ignored();
-    _alias = _name;
-    if ((_name = name()) == null) throw error('Field');
-    ignored();
-  }
-  const _arguments = arguments_(false);
-  const _directives = directives(false);
-  let _selectionSet: ast.SelectionSetNode | undefined;
-  if (input.charCodeAt(idx) === 123 /*'{'*/) {
-    idx++;
-    ignored();
-    _selectionSet = selectionSet();
-  }
-  return {
-    kind: 'Field' as Kind.FIELD,
-    alias: _alias,
-    name: _name,
-    arguments: _arguments,
-    directives: _directives,
-    selectionSet: _selectionSet,
-  };
-}
-
 function type(): ast.TypeNode {
   let match: ast.NameNode | ast.TypeNode | undefined;
   ignored();
@@ -382,8 +351,35 @@ function selectionSet(): ast.SelectionSetNode {
         ignored();
         selections.push(fragmentSpread());
       } else if ((match = exec[SelectionGroup.Name]) != null) {
+        let _alias: ast.NameNode | undefined;
+        let _name: ast.NameNode | undefined = {
+          kind: 'Name' as Kind.NAME,
+          value: match,
+        };
         ignored();
-        selections.push(field(match));
+        if (input.charCodeAt(idx) === 58 /*':'*/) {
+          idx++;
+          ignored();
+          _alias = _name;
+          if ((_name = name()) == null) throw error('Field');
+          ignored();
+        }
+        const _arguments = arguments_(false);
+        const _directives = directives(false);
+        let _selectionSet: ast.SelectionSetNode | undefined;
+        if (input.charCodeAt(idx) === 123 /*'{'*/) {
+          idx++;
+          ignored();
+          _selectionSet = selectionSet();
+        }
+        selections.push({
+          kind: 'Field' as Kind.FIELD,
+          alias: _alias,
+          name: _name,
+          arguments: _arguments,
+          directives: _directives,
+          selectionSet: _selectionSet,
+        });
       }
     } else {
       throw error('SelectionSet');


### PR DESCRIPTION
## Set of changes

- Refactor approach to `value()` parsing to combine all matches into single regex
  - Collapse object and list parsing into the `value()` parser
- Refactor multiple loop conditions (in `arguments()`, `variableDefinitions()`) to assume items or empty result
- Avoid returning empty `directives`, `arguments`, and `variableDefinitions` arrays to avoid redundant allocations
- Squash away `typeCondition()` and `name()` helpers
- Collapse `selectionSet()` parser to combine fragment and field parsers into one loop
- Remove some redundant `ignore()` calls

**Note:** The benchmarks fluctuate. Sometimes the new code will reach >150K Hz, sometimes it won't.

### Before

```
@0no-co/graphql.web  111,997.84  0.0075  0.8377  0.0089  0.0083  0.0334  0.0338  0.0581  ±0.55%    56000
```

### After

```
@0no-co/graphql.web  150,803.82  0.0058  0.6025  0.0066  0.0065  0.0087  0.0096  0.0651  ±0.38%    75404   fastest
```

This now consistently beats `graphql` parsing performance in our benchmarks.