### PR TITLE
Fix the `@ts-ignore` directive on TS import in type declaration output

### DIFF
--- a/.changeset/serious-hotels-shake.md
+++ b/.changeset/serious-hotels-shake.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphql.web": patch
+---
+
+Fix the directive syntax for ignoring errors due to unavailable peer dependencies.

--- a/.changeset/serious-hotels-shake.md
+++ b/.changeset/serious-hotels-shake.md
@@ -2,4 +2,4 @@
 "@0no-co/graphql.web": patch
 ---
 
-Fix the directive syntax for ignoring errors due to unavailable peer dependencies.
+Fix `@ts-ignore` on TypeScript peer dependency import in typings not being applied due to a leading `!` character.

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -233,7 +233,7 @@ export default [
           renderChunk(code, chunk) {
             if (chunk.fileName.endsWith('d.ts')) {
               const gqlImportRe = /(import\s+(?:[*\s{}\w\d]+)\s*from\s*'graphql';?)/g;
-              code = code.replace(gqlImportRe, x => '/*!@ts-ignore*/\n' + x);
+              code = code.replace(gqlImportRe, x => '/*@ts-ignore*/\n' + x);
 
               code = prettier.format(code, {
                 filepath: chunk.fileName,


### PR DESCRIPTION
Hello,

Currently, the following directive is produced:

```javascript
/*!@ts-ignore*/
```

However, it is not recognized by the compiler due to the exclamation mark in front.