### PR TITLE
fix: Fix typo causing complex string parsing to fail on subsequent runs

### DIFF
--- a/.changeset/two-days-nail.md
+++ b/.changeset/two-days-nail.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Fix typo causing complex string parsing to fail on subsequent runs.

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -73,6 +73,23 @@ describe('parse', () => {
     }).toThrow();
   });
 
+  it('parses escaped characters', () => {
+    let ast = parse(`
+      { field(arg: "Has another \\\\x sequence.") }
+    `);
+    expect(ast).toHaveProperty(
+      'definitions.0.selectionSet.selections.0.arguments.0.value.value',
+      'Has another \\x sequence.'
+    );
+    ast = parse(`
+      { field(arg: "Has a \\\\x sequence.") }
+    `);
+    expect(ast).toHaveProperty(
+      'definitions.0.selectionSet.selections.0.arguments.0.value.value',
+      'Has a \\x sequence.'
+    );
+  });
+
   it('parses multi-byte characters', () => {
     // Note: \u0A0A could be naively interpreted as two line-feed chars.
     const ast = parse(`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -105,7 +105,7 @@ type ValueExec = RegExpExecArray & {
   [Prop in ValueGroup]: string | undefined;
 };
 
-const complexStringRe = /\\/g;
+const complexStringRe = /\\/;
 
 function value(constant: true): ast.ConstValueNode;
 function value(constant: boolean): ast.ValueNode;


### PR DESCRIPTION
Resolve https://github.com/0no-co/gql.tada/issues/379

## Summary

This causes `"\\"` escape sequences in strings to not be detected the second time around, since `lastIndex` doesn't reset due to the typo of `g` added to the regex.

## Set of changes

- Fix stateful regex check
