### PR TITLE
Backport GraphQL-Tag fix

### DIFF
--- a/.changeset/tiny-gifts-exercise.md
+++ b/.changeset/tiny-gifts-exercise.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Add `loc` getter to parsed `DocumentNode` fragment outputs to ensure that using fragments created by `gql.tada`'s `graphql()` function with `graphql-tag` doesn't crash. `graphql-tag` does not treat the `DocumentNode.loc` property as optional on interpolations, which leads to intercompatibility issues.

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -6,7 +6,7 @@ import { Kind } from '../kind';
 
 describe('parse', () => {
   it('parses the kitchen sink document like graphql.js does', () => {
-    const doc = parse(kitchenSinkDocument);
+    const doc = parse(kitchenSinkDocument, { noLocation: true });
     expect(doc).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Mirrors the fix we did in https://github.com/0no-co/gql.tada/pull/396 - GraphQL-Tag uses the `sourceLocation` to index their fragments, we can't fully get around this in cases like the apollo-client InMemoryCache when `cache.modify` is used they'll invoke graphql-tag to parse the passed in string.