### PR TITLE
Disable Terser Mangle for Turbopack Compatibility

### DIFF
--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -150,7 +150,7 @@ const outputPlugins = [
       join_vars: false,
     },
     mangle: {
-      module: true,
+      module: false,
       keep_fnames: true,
     },
     output: {


### PR DESCRIPTION
## Summary

This pull request addresses an issue where the `Kind` object was incorrectly transformed when building the package with Turbopack, specifically when used together with the `gql.tada` package. Specifically, when using the `mangle` option in the Terser plugin, the `Kind` constant was renamed to `e`, leading to runtime errors due to undefined references (`"Kind": () => e`).

Turbopack, unlike Webpack, can be sensitive to the mangling of variable names, and this was causing issues with the way `Kind` was being referenced. By disabling the mangling of variable names, we ensure that the `Kind` object retains its original name in the final build, making it compatible with Turbopack.

## Set of changes

- Disabled the `mangle` option in Terser: The mangling of variable names has been turned off to prevent Turbopack from misinterpreting `Kind` as `e`.

## Impact

- This change ensures that the `Kind` object and other constants are not renamed during the build process, making the package work correctly with Turbopack while preserving the intended behavior.
- No changes to other parts of the package functionality. This change only affects the bundling behavior to ensure compatibility with Turbopack.

## How to verify

- Build the package using Turbopack and verify that no runtime errors occur related to undefined variables.
- Run the package with both Turbopack and Webpack to ensure compatibility with both bundlers.

---

## Visuals

### 1. Before the Change (with Mangling enabled):



<img width="1124" alt="image" src="https://github.com/user-attachments/assets/d3a2973e-1edd-482c-be74-1c9109f3d388">  |  <img width="1124" alt="image" src="https://github.com/user-attachments/assets/b54dfcd1-fd37-4ef6-927b-a89a4b08f947">
:-------------------------:|:-------------------------:

`
__TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f2e$pnpm$2f40$0no$2d$co$2b$graphql$2e$web$40$1$2e$0$2e$11_graphql$40$16$2e$9$2e$0$2f$node_modules$2f40$0no$2d$co$2f$graphql$2e$web$2f$dist$2f$graphql$2e$web$2e$mjs__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__["Kind"] -> references 'e', which is 'undefined' in this case
`

![image](https://github.com/user-attachments/assets/8f85946b-262e-47b6-803b-db6f4e8b0c6c)
:----------------------------------------------------:

### 2. After the Change (with Mangling disabled):

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/e82d65d5-a711-441d-b489-d71604a24912"> | <img width="1125" alt="image" src="https://github.com/user-attachments/assets/5f96fe75-375c-4766-9464-d1620dddb16d">
:-------------------------:|:-------------------------:

`
__TURBOPACK__imported__module__$5b$project$5d2f$node_modules$2f2e$pnpm$2f40$0no$2d$co$2b$graphql$2e$web$40$1$2e$0$2e$11_graphql$40$16$2e$9$2e$0$2f$node_modules$2f40$0no$2d$co$2f$graphql$2e$web$2f$dist$2f$graphql$2e$web$2e$mjs__$5b$app$2d$rsc$5d$__$28$ecmascript$29$__["Kind"] -> references 'Kind' correctly
`


## Related Discussions/Issues:

[ReferenceError: e is not defined error occurs when running next dev --turbo](https://github.com/vercel/next.js/issues/72232)
[Error after update to v1.0.10](https://github.com/0no-co/graphql.web/issues/42)
