### PR TITLE
Handle empty selection array

### DIFF
--- a/.changeset/soft-penguins-switch.md
+++ b/.changeset/soft-penguins-switch.md
@@ -2,4 +2,4 @@
 '@0no-co/graphql.web': patch
 ---
 
-Handle selection-sets with an empty selections array in a `documentNode`.
+Fix printing when a manually created AST node with an empty selection set array is passed to the printer

--- a/.changeset/soft-penguins-switch.md
+++ b/.changeset/soft-penguins-switch.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Handle selection-sets with an empty selections array in a `documentNode`.

--- a/src/__tests__/printer.test.ts
+++ b/src/__tests__/printer.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import * as graphql16 from 'graphql16';
 
+import type { DocumentNode } from '../ast';
 import { parse } from '../parser';
 import { print, printString, printBlockString } from '../printer';
 import kitchenSinkAST from './fixtures/kitchen_sink.json';
+import { Kind, OperationTypeNode } from 'src/kind';
 
 function dedentString(string: string) {
   const trimmedStr = string
@@ -176,6 +178,41 @@ describe('print', () => {
           dateTime
         }
       }
+    `
+    );
+  });
+
+  it('Handles empty array selections', () => {
+    const document: DocumentNode = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        {
+          kind: Kind.OPERATION_DEFINITION,
+          operation: OperationTypeNode.QUERY,
+          name: undefined,
+          selectionSet: {
+            kind: Kind.SELECTION_SET,
+            selections: [
+              {
+                kind: Kind.FIELD,
+                name: { kind: Kind.NAME, value: 'id' },
+                alias: undefined,
+                arguments: [],
+                directives: [],
+                selectionSet: { kind: Kind.SELECTION_SET, selections: [] },
+              },
+            ],
+          },
+          variableDefinitions: [],
+        },
+      ],
+    };
+
+    expect(print(document)).toBe(
+      dedent`
+        {
+          id
+        }
     `
     );
   });

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -132,7 +132,6 @@ const nodes = {
     return mapJoin(node.definitions, '\n\n', _print);
   },
   SelectionSet(node: SelectionSetNode): string {
-    if (!node.selections.length) return '';
     return '{' + (LF += '  ') + mapJoin(node.selections, LF, _print) + (LF = LF.slice(0, -2)) + '}';
   },
   Argument(node: ArgumentNode): string {

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -85,7 +85,9 @@ const nodes = {
     }
     if (node.directives && node.directives.length)
       out += ' ' + mapJoin(node.directives, ' ', nodes.Directive);
-    if (node.selectionSet) out += ' ' + nodes.SelectionSet(node.selectionSet);
+    if (node.selectionSet && node.selectionSet.selections.length) {
+      out += ' ' + nodes.SelectionSet(node.selectionSet);
+    }
     return out;
   },
   StringValue(node: StringValueNode): string {
@@ -130,6 +132,7 @@ const nodes = {
     return mapJoin(node.definitions, '\n\n', _print);
   },
   SelectionSet(node: SelectionSetNode): string {
+    if (!node.selections.length) return '';
     return '{' + (LF += '  ') + mapJoin(node.selections, LF, _print) + (LF = LF.slice(0, -2)) + '}';
   },
   Argument(node: ArgumentNode): string {


### PR DESCRIPTION
Resolves #45 

## Summary

When a DocumentNode is passed with an empty array (valid - can come from other sources - like a compile step in the bundle). We would print `{ }`, this is circumvented with a check in `Field` to avoid the empty space and printing the curlies.

## Set of changes

- Handle empty selections
