### PR TITLE
Eliminate duplicated strings in bundle

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,49 @@
+name: Compressed Size
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '**/src/**/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - name: Use pnpm store
+        uses: actions/cache@v4
+        id: pnpm-cache
+        with:
+          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          build-command: 'npm run build'

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -10,15 +10,16 @@ import terser from '@rollup/plugin-terser';
 import cjsCheck from 'rollup-plugin-cjs-check';
 import dts from 'rollup-plugin-dts';
 
-const normalize = name => []
-  .concat(name)
-  .join(' ')
-  .replace(/[@\s/.]+/g, ' ')
-  .trim()
-  .replace(/\s+/, '-')
-  .toLowerCase();
+const normalize = (name) =>
+  []
+    .concat(name)
+    .join(' ')
+    .replace(/[@\s/.]+/g, ' ')
+    .trim()
+    .replace(/\s+/, '-')
+    .toLowerCase();
 
-const extension = name => {
+const extension = (name) => {
   if (/\.d.ts$/.test(name)) {
     return '.d.ts';
   } else {
@@ -104,23 +105,27 @@ const outputPlugins = [
         const entry = exports[key];
         if (entry.path) {
           const output = path.relative(entry.path, process.cwd());
-          const json = JSON.stringify({
-            name: key,
-            private: true,
-            version: '0.0.0',
-            main: path.join(output, entry.require),
-            module: path.join(output, entry.import),
-            types: path.join(output, entry.types),
-            source: path.join(output, entry.source),
-            exports: {
-              '.': {
-                types: path.join(output, entry.types),
-                import: path.join(output, entry.import),
-                require: path.join(output, entry.require),
-                source: path.join(output, entry.source),
+          const json = JSON.stringify(
+            {
+              name: key,
+              private: true,
+              version: '0.0.0',
+              main: path.join(output, entry.require),
+              module: path.join(output, entry.import),
+              types: path.join(output, entry.types),
+              source: path.join(output, entry.source),
+              exports: {
+                '.': {
+                  types: path.join(output, entry.types),
+                  import: path.join(output, entry.import),
+                  require: path.join(output, entry.require),
+                  source: path.join(output, entry.source),
+                },
               },
             },
-          }, null, 2);
+            null,
+            2
+          );
 
           await fs.mkdir(entry.path, { recursive: true });
           await fs.writeFile(path.join(entry.path, 'package.json'), json);
@@ -172,10 +177,7 @@ export default [
         extensions: ['mjs', 'js', 'jsx', 'ts', 'tsx'],
         exclude: 'node_modules/**',
         presets: [],
-        plugins: [
-          '@babel/plugin-transform-typescript',
-          '@babel/plugin-transform-block-scoping',
-        ],
+        plugins: ['@babel/plugin-transform-typescript', '@babel/plugin-transform-block-scoping'],
       }),
     ],
     output: [
@@ -186,9 +188,7 @@ export default [
           return `dist/chunks/[name]-chunk${extension(chunk.name) || '.mjs'}`;
         },
         entryFileNames(chunk) {
-          return chunk.isEntry
-            ? path.normalize(exports[chunk.name].import)
-            : `dist/[name].mjs`;
+          return chunk.isEntry ? path.normalize(exports[chunk.name].import) : `dist/[name].mjs`;
         },
         plugins: outputPlugins,
       },
@@ -201,9 +201,7 @@ export default [
           return `dist/chunks/[name]-chunk${extension(chunk.name) || '.js'}`;
         },
         entryFileNames(chunk) {
-          return chunk.isEntry
-            ? path.normalize(exports[chunk.name].require)
-            : `dist/[name].js`;
+          return chunk.isEntry ? path.normalize(exports[chunk.name].require) : `dist/[name].js`;
         },
         plugins: outputPlugins,
       },
@@ -212,10 +210,7 @@ export default [
 
   {
     ...commonConfig,
-    plugins: [
-      ...commonPlugins,
-      dts(),
-    ],
+    plugins: [...commonPlugins, dts()],
     output: {
       ...commonOutput,
       sourcemap: false,
@@ -224,16 +219,14 @@ export default [
         return `dist/chunks/[name]-chunk${extension(chunk.name) || '.d.ts'}`;
       },
       entryFileNames(chunk) {
-        return chunk.isEntry
-          ? path.normalize(exports[chunk.name].types)
-          : `dist/[name].d.ts`;
+        return chunk.isEntry ? path.normalize(exports[chunk.name].types) : `dist/[name].d.ts`;
       },
       plugins: [
         {
           renderChunk(code, chunk) {
             if (chunk.fileName.endsWith('d.ts')) {
               const gqlImportRe = /(import\s+(?:[*\s{}\w\d]+)\s*from\s*'graphql';?)/g;
-              code = code.replace(gqlImportRe, x => '/*@ts-ignore*/\n' + x);
+              code = code.replace(gqlImportRe, (x) => '/*@ts-ignore*/\n' + x);
 
               code = prettier.format(code, {
                 filepath: chunk.fileName,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,8 +1,13 @@
 import type { Location, Source as _Source } from './types';
 import type { ASTNode, SelectionNode } from './ast';
+import { Kind } from './kind';
 
 export function isSelectionNode(node: ASTNode): node is SelectionNode {
-  return node.kind === 'Field' || node.kind === 'FragmentSpread' || node.kind === 'InlineFragment';
+  return (
+    node.kind === Kind.FIELD ||
+    node.kind === Kind.FRAGMENT_SPREAD ||
+    node.kind === Kind.INLINE_FRAGMENT
+  );
 }
 
 export function Source(body: string, name?: string, locationOffset?: Location): _Source {

--- a/src/values.ts
+++ b/src/values.ts
@@ -1,3 +1,4 @@
+import { Kind } from './kind';
 import type { TypeNode, ValueNode } from './ast';
 import type { Maybe } from './types';
 
@@ -6,23 +7,23 @@ export function valueFromASTUntyped(
   variables?: Maybe<Record<string, any>>
 ): unknown {
   switch (node.kind) {
-    case 'NullValue':
+    case Kind.NULL:
       return null;
-    case 'IntValue':
+    case Kind.INT:
       return parseInt(node.value, 10);
-    case 'FloatValue':
+    case Kind.FLOAT:
       return parseFloat(node.value);
-    case 'StringValue':
-    case 'EnumValue':
-    case 'BooleanValue':
+    case Kind.STRING:
+    case Kind.ENUM:
+    case Kind.BOOLEAN:
       return node.value;
-    case 'ListValue': {
+    case Kind.LIST: {
       const values: unknown[] = [];
       for (let i = 0, l = node.values.length; i < l; i++)
         values.push(valueFromASTUntyped(node.values[i], variables));
       return values;
     }
-    case 'ObjectValue': {
+    case Kind.OBJECT: {
       const obj = Object.create(null);
       for (let i = 0, l = node.fields.length; i < l; i++) {
         const field = node.fields[i];
@@ -30,7 +31,7 @@ export function valueFromASTUntyped(
       }
       return obj;
     }
-    case 'Variable':
+    case Kind.VARIABLE:
       return variables && variables[node.name.value];
   }
 }
@@ -40,15 +41,15 @@ export function valueFromTypeNode(
   type: TypeNode,
   variables?: Maybe<Record<string, any>>
 ): unknown {
-  if (node.kind === 'Variable') {
+  if (node.kind === Kind.VARIABLE) {
     const variableName = node.name.value;
     return variables ? valueFromTypeNode(variables[variableName], type, variables) : undefined;
-  } else if (type.kind === 'NonNullType') {
-    return node.kind !== 'NullValue' ? valueFromTypeNode(node, type, variables) : undefined;
-  } else if (node.kind === 'NullValue') {
+  } else if (type.kind === Kind.NON_NULL_TYPE) {
+    return node.kind !== Kind.NULL ? valueFromTypeNode(node, type, variables) : undefined;
+  } else if (node.kind === Kind.NULL) {
     return null;
-  } else if (type.kind === 'ListType') {
-    if (node.kind === 'ListValue') {
+  } else if (type.kind === Kind.LIST_TYPE) {
+    if (node.kind === Kind.LIST) {
       const values: unknown[] = [];
       for (let i = 0, l = node.values.length; i < l; i++) {
         const value = node.values[i];
@@ -61,7 +62,7 @@ export function valueFromTypeNode(
       }
       return values;
     }
-  } else if (type.kind === 'NamedType') {
+  } else if (type.kind === Kind.NAMED_TYPE) {
     switch (type.name.value) {
       case 'Int':
       case 'Float':


### PR DESCRIPTION
## Summary

Re-using `Kind` should remove a lot of the duplicated strings in our bundle as well as increase performance due to a reduction of adhoc String allocations.

EDIT: hmm, I would have assumed that the variable usage would improve the bundle size, not worsen it 😅 this is a bit odd to say the least, I guess the repeated strings is being offset due to GZIP
