### PR TITLE
fix: compatibility with typescript 5.5 and higher

### DIFF
--- a/.changeset/bright-baboons-chew.md
+++ b/.changeset/bright-baboons-chew.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Fix compatibility with typescript 5.5 and higher

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Or<T, U> = 0 extends 1 & T ? U : T;
+export type Or<T, U> = void extends T ? U : T;
 
 export type Maybe<T> = T | undefined | null;
 


### PR DESCRIPTION
<!--
  Thanks for opening a pull request! We appreciate your dedication and help!
  Before submitting your pull request, please make sure to read our CONTRIBUTING guide.

  The best contribution is always a PR, but please make sure to open an issue or discuss
  your changes first, if you’re looking to submit a larger PR.

  If this PR is already related to an issue, please reference it like so:
  Resolves #123
-->

## Summary

TypeScript changed the behaviour of "unresolved" any from 5.5 so doing `type Doc = Or<UnresolvedType, LocalType>` will always be `any`. Here is the reference to the issue, and it's not considered a defect https://github.com/microsoft/TypeScript/issues/58960

<!-- What's the motivation of this change? What does it solve? -->

## Set of changes

This PR changes the `Or` utility type to:
```typescript
type Or<T, U> = void extends T ? U : T;
```
Which is compatible with both newer and older versions of TypeScript

<!--
  Roughly list the changes you've made and which packages are affected.
  Leave some notes on what may be noteworthy files you've changed.
  And lastly, please let us know if you think this is a breaking change.
-->
