### PR TITLE
chore: Remove `sourcesContent` from published sourcemaps

### DIFF
--- a/.changeset/warm-numbers-attack.md
+++ b/.changeset/warm-numbers-attack.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphql.web": patch
+---
+
+Remove sourcemaps' `sourcesContent` from published package

--- a/scripts/rollup.config.mjs
+++ b/scripts/rollup.config.mjs
@@ -83,7 +83,7 @@ const commonOutput = {
   dir: './',
   exports: 'auto',
   sourcemap: true,
-  sourcemapExcludeSources: false,
+  sourcemapExcludeSources: true,
   hoistTransitiveImports: false,
   indent: false,
   freeze: false,


### PR DESCRIPTION
Related: https://github.com/urql-graphql/urql/pull/3755

## Summary

This adds no value since the output will already be pretty+minified and will be mostly the same as the input.

## Set of changes

- Remove `sourcesContent` from output sourcemaps
