### PR TITLE
fix: Handle unexpected EOF for comments (end of input)

### DIFF
--- a/.changeset/mighty-frogs-push.md
+++ b/.changeset/mighty-frogs-push.md
@@ -1,0 +1,5 @@
+---
+"@0no-co/graphql.web": patch
+---
+
+Handle trailing comment ending in EOF (end of input)

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -10,6 +10,14 @@ describe('parse', () => {
     expect(doc).toMatchSnapshot();
   });
 
+  it('parses unexpected EOF', () => {
+    expect(() => parse('#')).toThrow();
+    expect(() => parse(' ')).toThrow();
+    expect(() => parse('q($')).toThrow();
+    expect(() => parse('{x{')).toThrow();
+    expect(() => parse('#\n')).toThrow();
+  });
+
   it('parses basic documents', () => {
     expect(() => parse('{')).toThrow();
     expect(() => parse('{}x  ')).toThrow();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,7 +60,7 @@ function ignored() {
     char === 65279 /*'\ufeff'*/;
     char = input.charCodeAt(idx++) | 0
   ) {
-    if (char === 35 /*'#'*/) while ((char = input.charCodeAt(idx++)) !== 10 && char !== 13);
+    if (char === 35 /*'#'*/) while ((char = input.charCodeAt(idx++) | 0) && char !== 10 && char !== 13);
   }
   idx--;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,7 +60,8 @@ function ignored() {
     char === 65279 /*'\ufeff'*/;
     char = input.charCodeAt(idx++) | 0
   ) {
-    if (char === 35 /*'#'*/) while ((char = input.charCodeAt(idx++) | 0) && char !== 10 && char !== 13);
+    if (char === 35 /*'#'*/)
+      while ((char = input.charCodeAt(idx++) | 0) && char !== 10 && char !== 13);
   }
   idx--;
 }


### PR DESCRIPTION
Resolve #61 

This was caused in a refactor a while back that didn't have appropriate test cases for the EOF edge case for comments (trailing comments not ending with trailing newline)