### PR TITLE
Smooth over kind incompatibility between `graphql@16` versions

### DIFF
--- a/fixtures/graphql16-new/index.ts
+++ b/fixtures/graphql16-new/index.ts
@@ -1,0 +1,90 @@
+import * as graphql from 'graphql';
+
+import { Kind, OperationTypeNode, parse, parseValue } from '../../src';
+import type {
+  ASTNode,
+  ArgumentCoordinateNode,
+  DirectiveArgumentCoordinateNode,
+  DirectiveCoordinateNode,
+  DocumentNode,
+  MemberCoordinateNode,
+  SchemaCoordinateNode,
+  TypeCoordinateNode,
+} from '../../src';
+
+export const constructedDocument: DocumentNode = {
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'id' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const typeCoordinate: TypeCoordinateNode = {
+  kind: Kind.TYPE_COORDINATE,
+  name: { kind: Kind.NAME, value: 'User' },
+};
+
+export const memberCoordinate: MemberCoordinateNode = {
+  kind: Kind.MEMBER_COORDINATE,
+  name: { kind: Kind.NAME, value: 'User' },
+  memberName: { kind: Kind.NAME, value: 'email' },
+};
+
+export const argumentCoordinate: ArgumentCoordinateNode = {
+  kind: Kind.ARGUMENT_COORDINATE,
+  name: { kind: Kind.NAME, value: 'Query' },
+  fieldName: { kind: Kind.NAME, value: 'user' },
+  argumentName: { kind: Kind.NAME, value: 'id' },
+};
+
+export const directiveCoordinate: DirectiveCoordinateNode = {
+  kind: Kind.DIRECTIVE_COORDINATE,
+  name: { kind: Kind.NAME, value: 'include' },
+};
+
+export const directiveArgumentCoordinate: DirectiveArgumentCoordinateNode = {
+  kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE,
+  name: { kind: Kind.NAME, value: 'include' },
+  argumentName: { kind: Kind.NAME, value: 'if' },
+};
+
+export function acceptsWebDocument(document: graphql.DocumentNode): DocumentNode {
+  return document;
+}
+
+export function acceptsGraphQLDocument(document: DocumentNode): graphql.DocumentNode {
+  return document;
+}
+
+export function acceptsWebASTNode(node: graphql.ASTNode): ASTNode {
+  return node;
+}
+
+export function acceptsGraphQLASTNode(node: ASTNode): graphql.ASTNode {
+  return node;
+}
+
+export function acceptsWebCoordinate(node: graphql.SchemaCoordinateNode): SchemaCoordinateNode {
+  return node;
+}
+
+export function acceptsGraphQLCoordinate(node: SchemaCoordinateNode): graphql.SchemaCoordinateNode {
+  return node;
+}
+
+export const graphqlParse: typeof graphql.parse = parse;
+export const webParse: typeof parse = graphql.parse;
+export const graphqlParseValue: typeof graphql.parseValue = parseValue;
+export const webParseValue: typeof parseValue = graphql.parseValue;

--- a/fixtures/graphql16-new/tsconfig.json
+++ b/fixtures/graphql16-new/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "graphql": ["node_modules/graphql16new"],
+    },
+  },
+  "include": ["index.ts"],
+}

--- a/fixtures/graphql16-old/index.ts
+++ b/fixtures/graphql16-old/index.ts
@@ -1,0 +1,44 @@
+import * as graphql from 'graphql';
+
+import { Kind, OperationTypeNode, parse, parseValue } from '../../src';
+import type { ASTNode, DocumentNode } from '../../src';
+
+export const constructedDocument: DocumentNode = {
+  kind: Kind.DOCUMENT,
+  definitions: [
+    {
+      kind: Kind.OPERATION_DEFINITION,
+      operation: OperationTypeNode.QUERY,
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: { kind: Kind.NAME, value: 'id' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export function acceptsWebDocument(document: graphql.DocumentNode): DocumentNode {
+  return document;
+}
+
+export function acceptsGraphQLDocument(document: DocumentNode): graphql.DocumentNode {
+  return document;
+}
+
+export function acceptsWebASTNode(node: graphql.ASTNode): ASTNode {
+  return node;
+}
+
+export function acceptsGraphQLASTNode(node: ASTNode): graphql.ASTNode {
+  return node;
+}
+
+export const graphqlParse: typeof graphql.parse = parse;
+export const webParse: typeof parse = graphql.parse;
+export const graphqlParseValue: typeof graphql.parseValue = parseValue;
+export const webParseValue: typeof parseValue = graphql.parseValue;

--- a/fixtures/graphql16-old/tsconfig.json
+++ b/fixtures/graphql16-old/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "graphql": ["node_modules/graphql16old"],
+    },
+  },
+  "include": ["index.ts"],
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "test": "vitest test",
     "bench": "vitest bench --typecheck.enabled=false",
-    "check": "tsc",
+    "check": "tsc && tsc -p fixtures/graphql16-old && tsc -p fixtures/graphql16-new",
     "lint": "eslint --ext=js,ts .",
     "build": "rollup -c scripts/rollup.config.mjs",
     "clean": "rimraf dist node_modules/.cache",
@@ -95,6 +95,8 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-tsdoc": "^0.2.17",
     "graphql15": "npm:graphql@^15.8.0",
+    "graphql16old": "npm:graphql@16.11.0",
+    "graphql16new": "npm:graphql@16.12.0",
     "graphql16": "npm:graphql@^16.12.0",
     "graphql17": "npm:graphql@^17.0.0-alpha.9",
     "graphql": "^16.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,12 @@ importers:
       graphql16:
         specifier: npm:graphql@^16.12.0
         version: graphql@16.12.0
+      graphql16new:
+        specifier: npm:graphql@16.12.0
+        version: graphql@16.12.0
+      graphql16old:
+        specifier: npm:graphql@16.11.0
+        version: graphql@16.11.0
       graphql17:
         specifier: npm:graphql@^17.0.0-alpha.9
         version: graphql@17.0.0-alpha.9
@@ -1434,6 +1440,10 @@ packages:
   graphql@15.8.0:
     resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
     engines: {node: '>= 10.x'}
+
+  graphql@16.11.0:
+    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   graphql@16.12.0:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
@@ -4130,6 +4140,8 @@ snapshots:
   graphemer@1.4.0: {}
 
   graphql@15.8.0: {}
+
+  graphql@16.11.0: {}
 
   graphql@16.12.0: {}
 

--- a/src/__tests__/graphql-version-compat.test-d.ts
+++ b/src/__tests__/graphql-version-compat.test-d.ts
@@ -1,0 +1,44 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type * as graphql16new from 'graphql16new';
+
+import type { ASTNode, DocumentNode } from '../ast';
+import type { Kind } from '../kind';
+import type {
+  SchemaCoordinateNode,
+  TypeCoordinateNode,
+  MemberCoordinateNode,
+  ArgumentCoordinateNode,
+  DirectiveCoordinateNode,
+  DirectiveArgumentCoordinateNode,
+} from '../coordinateAst';
+
+describe('graphql@16.12 compatibility', () => {
+  it('keeps Kind assignable after GraphQL added schema coordinate kinds', () => {
+    expectTypeOf<Kind>().toMatchTypeOf<graphql16new.Kind>();
+    expectTypeOf<graphql16new.Kind>().toMatchTypeOf<Kind>();
+    expectTypeOf<Kind.DOCUMENT>().toMatchTypeOf<graphql16new.Kind.DOCUMENT>();
+    expectTypeOf<graphql16new.Kind.DOCUMENT>().toMatchTypeOf<Kind.DOCUMENT>();
+  });
+
+  it('keeps AST node types assignable to the current GraphQL 16 AST', () => {
+    expectTypeOf<DocumentNode>().toMatchTypeOf<graphql16new.DocumentNode>();
+    expectTypeOf<graphql16new.DocumentNode>().toMatchTypeOf<DocumentNode>();
+    expectTypeOf<ASTNode>().toMatchTypeOf<graphql16new.ASTNode>();
+    expectTypeOf<graphql16new.ASTNode>().toMatchTypeOf<ASTNode>();
+  });
+
+  it('matches GraphQL schema coordinate AST nodes', () => {
+    expectTypeOf<SchemaCoordinateNode>().toMatchTypeOf<graphql16new.SchemaCoordinateNode>();
+    expectTypeOf<graphql16new.SchemaCoordinateNode>().toMatchTypeOf<SchemaCoordinateNode>();
+    expectTypeOf<TypeCoordinateNode>().toMatchTypeOf<graphql16new.TypeCoordinateNode>();
+    expectTypeOf<graphql16new.TypeCoordinateNode>().toMatchTypeOf<TypeCoordinateNode>();
+    expectTypeOf<MemberCoordinateNode>().toMatchTypeOf<graphql16new.MemberCoordinateNode>();
+    expectTypeOf<graphql16new.MemberCoordinateNode>().toMatchTypeOf<MemberCoordinateNode>();
+    expectTypeOf<ArgumentCoordinateNode>().toMatchTypeOf<graphql16new.ArgumentCoordinateNode>();
+    expectTypeOf<graphql16new.ArgumentCoordinateNode>().toMatchTypeOf<ArgumentCoordinateNode>();
+    expectTypeOf<DirectiveCoordinateNode>().toMatchTypeOf<graphql16new.DirectiveCoordinateNode>();
+    expectTypeOf<graphql16new.DirectiveCoordinateNode>().toMatchTypeOf<DirectiveCoordinateNode>();
+    expectTypeOf<DirectiveArgumentCoordinateNode>().toMatchTypeOf<graphql16new.DirectiveArgumentCoordinateNode>();
+    expectTypeOf<graphql16new.DirectiveArgumentCoordinateNode>().toMatchTypeOf<DirectiveArgumentCoordinateNode>();
+  });
+});

--- a/src/coordinateAst.ts
+++ b/src/coordinateAst.ts
@@ -1,59 +1,44 @@
-import type * as GraphQL from 'graphql';
-
-import type { Or, Location } from './types';
+import type { Location } from './types';
 import type { Kind } from './kind';
 import type { NameNode } from './ast';
 
-export declare type SchemaCoordinateNode = Or<
-  GraphQL.SchemaCoordinateNode,
-  TypeCoordinateNode | MemberCoordinateNode | ArgumentCoordinateNode | DirectiveCoordinateNode | DirectiveArgumentCoordinateNode
->;
+export declare type SchemaCoordinateNode =
+  | TypeCoordinateNode
+  | MemberCoordinateNode
+  | ArgumentCoordinateNode
+  | DirectiveCoordinateNode
+  | DirectiveArgumentCoordinateNode;
 
-export type TypeCoordinateNode = Or<
-  GraphQL.TypeCoordinateNode,
-  {
-    readonly kind: Kind.TYPE_COORDINATE;
-    readonly loc?: Location;
-    readonly name: NameNode;
-  }
->;
+export interface TypeCoordinateNode {
+  readonly kind: Kind.TYPE_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+}
 
-export type MemberCoordinateNode = Or<
-  GraphQL.MemberCoordinateNode,
-  {
-    readonly kind: Kind.MEMBER_COORDINATE;
-    readonly loc?: Location;
-    readonly name: NameNode;
-    readonly memberName: NameNode;
-  }
->;
+export interface MemberCoordinateNode {
+  readonly kind: Kind.MEMBER_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly memberName: NameNode;
+}
 
-export type ArgumentCoordinateNode = Or<
-  GraphQL.ArgumentCoordinateNode,
-  {
-    readonly kind: Kind.ARGUMENT_COORDINATE;
-    readonly loc?: Location;
-    readonly name: NameNode;
-    readonly fieldName: NameNode;
-    readonly argumentName: NameNode;
-  }
->;
+export interface ArgumentCoordinateNode {
+  readonly kind: Kind.ARGUMENT_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly fieldName: NameNode;
+  readonly argumentName: NameNode;
+}
 
-export type DirectiveCoordinateNode = Or<
-  GraphQL.DirectiveCoordinateNode,
-  {
-    readonly kind: Kind.DIRECTIVE_COORDINATE;
-    readonly loc?: Location;
-    readonly name: NameNode;
-  }
->;
+export interface DirectiveCoordinateNode {
+  readonly kind: Kind.DIRECTIVE_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+}
 
-export type DirectiveArgumentCoordinateNode = Or<
-  GraphQL.DirectiveArgumentCoordinateNode,
-  {
-    readonly kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE;
-    readonly loc?: Location;
-    readonly name: NameNode;
-    readonly argumentName: NameNode;
-  }
->;
+export interface DirectiveArgumentCoordinateNode {
+  readonly kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly argumentName: NameNode;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type { Source, Location, Extensions } from './types';
 
 export * from './ast';
 export * from './schemaAst';
+export * from './coordinateAst';
 export * from './kind';
 export * from './error';
 export * from './parser';

--- a/src/kind.d.ts
+++ b/src/kind.d.ts
@@ -1,68 +1,112 @@
 import type * as GraphQL from 'graphql';
 
-import type { Or } from './types';
+type GraphQLKind<
+  Key extends string,
+  Fallback extends string,
+> = Key extends keyof typeof GraphQL.Kind ? (typeof GraphQL.Kind)[Key] : Fallback;
 
-export declare enum Kind {
-  /** Name */
-  NAME = 'Name',
-  /** Document */
-  DOCUMENT = 'Document',
-  OPERATION_DEFINITION = 'OperationDefinition',
-  VARIABLE_DEFINITION = 'VariableDefinition',
-  SELECTION_SET = 'SelectionSet',
-  FIELD = 'Field',
-  ARGUMENT = 'Argument',
-  /** Fragments */
-  FRAGMENT_SPREAD = 'FragmentSpread',
-  INLINE_FRAGMENT = 'InlineFragment',
-  FRAGMENT_DEFINITION = 'FragmentDefinition',
-  /** Values */
-  VARIABLE = 'Variable',
-  INT = 'IntValue',
-  FLOAT = 'FloatValue',
-  STRING = 'StringValue',
-  BOOLEAN = 'BooleanValue',
-  NULL = 'NullValue',
-  ENUM = 'EnumValue',
-  LIST = 'ListValue',
-  OBJECT = 'ObjectValue',
-  OBJECT_FIELD = 'ObjectField',
-  /** Directives */
-  DIRECTIVE = 'Directive',
-  /** Types */
-  NAMED_TYPE = 'NamedType',
-  LIST_TYPE = 'ListType',
-  NON_NULL_TYPE = 'NonNullType',
-  /** Type System Definitions */
-  SCHEMA_DEFINITION = 'SchemaDefinition',
-  OPERATION_TYPE_DEFINITION = 'OperationTypeDefinition',
-  /** Type Definitions */
-  SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition',
-  OBJECT_TYPE_DEFINITION = 'ObjectTypeDefinition',
-  FIELD_DEFINITION = 'FieldDefinition',
-  INPUT_VALUE_DEFINITION = 'InputValueDefinition',
-  INTERFACE_TYPE_DEFINITION = 'InterfaceTypeDefinition',
-  UNION_TYPE_DEFINITION = 'UnionTypeDefinition',
-  ENUM_TYPE_DEFINITION = 'EnumTypeDefinition',
-  ENUM_VALUE_DEFINITION = 'EnumValueDefinition',
-  INPUT_OBJECT_TYPE_DEFINITION = 'InputObjectTypeDefinition',
-  /** Directive Definitions */
-  DIRECTIVE_DEFINITION = 'DirectiveDefinition',
-  /** Type System Extensions */
-  SCHEMA_EXTENSION = 'SchemaExtension',
-  /** Type Extensions */
-  SCALAR_TYPE_EXTENSION = 'ScalarTypeExtension',
-  OBJECT_TYPE_EXTENSION = 'ObjectTypeExtension',
-  INTERFACE_TYPE_EXTENSION = 'InterfaceTypeExtension',
-  UNION_TYPE_EXTENSION = 'UnionTypeExtension',
-  ENUM_TYPE_EXTENSION = 'EnumTypeExtension',
-  INPUT_OBJECT_TYPE_EXTENSION = 'InputObjectTypeExtension',
+export declare const Kind: typeof GraphQL.Kind & {
   /** Coordinates */
-  TYPE_COORDINATE = 'TypeCoordinate',
-  MEMBER_COORDINATE = 'MemberCoordinate',
-  ARGUMENT_COORDINATE = 'ArgumentCoordinate',
-  DIRECTIVE_COORDINATE = 'DirectiveCoordinate',
-  DIRECTIVE_ARGUMENT_COORDINATE = 'DirectiveArgumentCoordinate',
+  readonly TYPE_COORDINATE: GraphQLKind<'TYPE_COORDINATE', 'TypeCoordinate'>;
+  readonly MEMBER_COORDINATE: GraphQLKind<'MEMBER_COORDINATE', 'MemberCoordinate'>;
+  readonly ARGUMENT_COORDINATE: GraphQLKind<'ARGUMENT_COORDINATE', 'ArgumentCoordinate'>;
+  readonly DIRECTIVE_COORDINATE: GraphQLKind<'DIRECTIVE_COORDINATE', 'DirectiveCoordinate'>;
+  readonly DIRECTIVE_ARGUMENT_COORDINATE: GraphQLKind<
+    'DIRECTIVE_ARGUMENT_COORDINATE',
+    'DirectiveArgumentCoordinate'
+  >;
+};
+
+export type Kind = (typeof Kind)[keyof typeof Kind];
+
+export declare namespace Kind {
+  /** Name */
+  export type NAME = GraphQLKind<'NAME', 'Name'>;
+  /** Document */
+  export type DOCUMENT = GraphQLKind<'DOCUMENT', 'Document'>;
+  export type OPERATION_DEFINITION = GraphQLKind<'OPERATION_DEFINITION', 'OperationDefinition'>;
+  export type VARIABLE_DEFINITION = GraphQLKind<'VARIABLE_DEFINITION', 'VariableDefinition'>;
+  export type SELECTION_SET = GraphQLKind<'SELECTION_SET', 'SelectionSet'>;
+  export type FIELD = GraphQLKind<'FIELD', 'Field'>;
+  export type ARGUMENT = GraphQLKind<'ARGUMENT', 'Argument'>;
+  /** Fragments */
+  export type FRAGMENT_SPREAD = GraphQLKind<'FRAGMENT_SPREAD', 'FragmentSpread'>;
+  export type INLINE_FRAGMENT = GraphQLKind<'INLINE_FRAGMENT', 'InlineFragment'>;
+  export type FRAGMENT_DEFINITION = GraphQLKind<'FRAGMENT_DEFINITION', 'FragmentDefinition'>;
+  /** Values */
+  export type VARIABLE = GraphQLKind<'VARIABLE', 'Variable'>;
+  export type INT = GraphQLKind<'INT', 'IntValue'>;
+  export type FLOAT = GraphQLKind<'FLOAT', 'FloatValue'>;
+  export type STRING = GraphQLKind<'STRING', 'StringValue'>;
+  export type BOOLEAN = GraphQLKind<'BOOLEAN', 'BooleanValue'>;
+  export type NULL = GraphQLKind<'NULL', 'NullValue'>;
+  export type ENUM = GraphQLKind<'ENUM', 'EnumValue'>;
+  export type LIST = GraphQLKind<'LIST', 'ListValue'>;
+  export type OBJECT = GraphQLKind<'OBJECT', 'ObjectValue'>;
+  export type OBJECT_FIELD = GraphQLKind<'OBJECT_FIELD', 'ObjectField'>;
+  /** Directives */
+  export type DIRECTIVE = GraphQLKind<'DIRECTIVE', 'Directive'>;
+  /** Types */
+  export type NAMED_TYPE = GraphQLKind<'NAMED_TYPE', 'NamedType'>;
+  export type LIST_TYPE = GraphQLKind<'LIST_TYPE', 'ListType'>;
+  export type NON_NULL_TYPE = GraphQLKind<'NON_NULL_TYPE', 'NonNullType'>;
+  /** Type System Definitions */
+  export type SCHEMA_DEFINITION = GraphQLKind<'SCHEMA_DEFINITION', 'SchemaDefinition'>;
+  export type OPERATION_TYPE_DEFINITION = GraphQLKind<
+    'OPERATION_TYPE_DEFINITION',
+    'OperationTypeDefinition'
+  >;
+  /** Type Definitions */
+  export type SCALAR_TYPE_DEFINITION = GraphQLKind<
+    'SCALAR_TYPE_DEFINITION',
+    'ScalarTypeDefinition'
+  >;
+  export type OBJECT_TYPE_DEFINITION = GraphQLKind<
+    'OBJECT_TYPE_DEFINITION',
+    'ObjectTypeDefinition'
+  >;
+  export type FIELD_DEFINITION = GraphQLKind<'FIELD_DEFINITION', 'FieldDefinition'>;
+  export type INPUT_VALUE_DEFINITION = GraphQLKind<
+    'INPUT_VALUE_DEFINITION',
+    'InputValueDefinition'
+  >;
+  export type INTERFACE_TYPE_DEFINITION = GraphQLKind<
+    'INTERFACE_TYPE_DEFINITION',
+    'InterfaceTypeDefinition'
+  >;
+  export type UNION_TYPE_DEFINITION = GraphQLKind<'UNION_TYPE_DEFINITION', 'UnionTypeDefinition'>;
+  export type ENUM_TYPE_DEFINITION = GraphQLKind<'ENUM_TYPE_DEFINITION', 'EnumTypeDefinition'>;
+  export type ENUM_VALUE_DEFINITION = GraphQLKind<'ENUM_VALUE_DEFINITION', 'EnumValueDefinition'>;
+  export type INPUT_OBJECT_TYPE_DEFINITION = GraphQLKind<
+    'INPUT_OBJECT_TYPE_DEFINITION',
+    'InputObjectTypeDefinition'
+  >;
+  /** Directive Definitions */
+  export type DIRECTIVE_DEFINITION = GraphQLKind<'DIRECTIVE_DEFINITION', 'DirectiveDefinition'>;
+  /** Type System Extensions */
+  export type SCHEMA_EXTENSION = GraphQLKind<'SCHEMA_EXTENSION', 'SchemaExtension'>;
+  /** Type Extensions */
+  export type SCALAR_TYPE_EXTENSION = GraphQLKind<'SCALAR_TYPE_EXTENSION', 'ScalarTypeExtension'>;
+  export type OBJECT_TYPE_EXTENSION = GraphQLKind<'OBJECT_TYPE_EXTENSION', 'ObjectTypeExtension'>;
+  export type INTERFACE_TYPE_EXTENSION = GraphQLKind<
+    'INTERFACE_TYPE_EXTENSION',
+    'InterfaceTypeExtension'
+  >;
+  export type UNION_TYPE_EXTENSION = GraphQLKind<'UNION_TYPE_EXTENSION', 'UnionTypeExtension'>;
+  export type ENUM_TYPE_EXTENSION = GraphQLKind<'ENUM_TYPE_EXTENSION', 'EnumTypeExtension'>;
+  export type INPUT_OBJECT_TYPE_EXTENSION = GraphQLKind<
+    'INPUT_OBJECT_TYPE_EXTENSION',
+    'InputObjectTypeExtension'
+  >;
+  /** Coordinates */
+  export type TYPE_COORDINATE = GraphQLKind<'TYPE_COORDINATE', 'TypeCoordinate'>;
+  export type MEMBER_COORDINATE = GraphQLKind<'MEMBER_COORDINATE', 'MemberCoordinate'>;
+  export type ARGUMENT_COORDINATE = GraphQLKind<'ARGUMENT_COORDINATE', 'ArgumentCoordinate'>;
+  export type DIRECTIVE_COORDINATE = GraphQLKind<'DIRECTIVE_COORDINATE', 'DirectiveCoordinate'>;
+  export type DIRECTIVE_ARGUMENT_COORDINATE = GraphQLKind<
+    'DIRECTIVE_ARGUMENT_COORDINATE',
+    'DirectiveArgumentCoordinate'
+  >;
 }
 
 export declare enum OperationTypeNode {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -443,7 +443,10 @@ function variableDefinitions(): ast.VariableDefinitionNode[] | undefined {
       }
       ignored();
       const varDef: ast.VariableDefinitionNode = {
-        kind: 'VariableDefinition' as Or<GraphQL.Kind.VARIABLE_DEFINITION, Kind.VARIABLE_DEFINITION>,
+        kind: 'VariableDefinition' as Or<
+          GraphQL.Kind.VARIABLE_DEFINITION,
+          Kind.VARIABLE_DEFINITION
+        >,
         variable: {
           kind: 'Variable' as Or<GraphQL.Kind.VARIABLE, Kind.VARIABLE>,
           name,
@@ -497,7 +500,10 @@ function definitions(): ast.DefinitionNode[] {
       idx++;
       ignored();
       _definitions.push({
-        kind: 'OperationDefinition' as Or<GraphQL.Kind.OPERATION_DEFINITION, Kind.OPERATION_DEFINITION>,
+        kind: 'OperationDefinition' as Or<
+          GraphQL.Kind.OPERATION_DEFINITION,
+          Kind.OPERATION_DEFINITION
+        >,
         operation: 'query' as OperationTypeNode.QUERY,
         name: undefined,
         variableDefinitions: undefined,
@@ -523,7 +529,10 @@ function definitions(): ast.DefinitionNode[] {
             name = nameNode();
           }
           const opDef: ast.OperationDefinitionNode = {
-            kind: 'OperationDefinition' as Or<GraphQL.Kind.OPERATION_DEFINITION, Kind.OPERATION_DEFINITION>,
+            kind: 'OperationDefinition' as Or<
+              GraphQL.Kind.OPERATION_DEFINITION,
+              Kind.OPERATION_DEFINITION
+            >,
             operation: definition as OperationTypeNode,
             name,
             variableDefinitions: variableDefinitions(),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         '**/__tests__/**',
         '**/*.d.ts',
         'src/ast.ts',
+        'src/coordinateAst.ts',
         'src/index.ts',
         'src/schemaAst.ts',
         'src/types.ts',


### PR DESCRIPTION
## Summary

The changes made in a minor release in `graphql` amount to a breaking change, due to them having missed that enum modifications are essentially breaking in many cases, since in TypeScript each enum value represents a globally unique symbol. This means that compatibility across `graphql@16` versions is extremely difficult.

For us, since we're smoothing this over, this means that we can only represent this value by imitating the `enum` value with a namespace and the `type` with a record map.

## Set of changes

- Smooth over enum value differences
- Create test fixture