### PR TITLE
Fix DocumentNode compatibility with exact optional properties

### DIFF
--- a/.changeset/tidy-bags-fix.md
+++ b/.changeset/tidy-bags-fix.md
@@ -1,0 +1,5 @@
+---
+'@0no-co/graphql.web': patch
+---
+
+Allow `undefined` on `DocumentNode.tokenCount` to preserve compatibility with `graphql` when `exactOptionalPropertyTypes` is enabled.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -99,12 +99,12 @@ export type NameNode = Or<
 >;
 
 export type DocumentNode = Or<
-  GraphQL.DocumentNode & { readonly tokenCount?: number },
+  GraphQL.DocumentNode & { readonly tokenCount?: number | undefined },
   {
     readonly kind: Kind.DOCUMENT;
     readonly definitions: ReadonlyArray<DefinitionNode>;
     readonly loc?: Location;
-    readonly tokenCount?: number;
+    readonly tokenCount?: number | undefined;
   }
 >;
 


### PR DESCRIPTION
## Summary

- Allow explicit `undefined` on the optional `DocumentNode.tokenCount` property
- Preserve assignability with `graphql`'s `DocumentNode` when `exactOptionalPropertyTypes` is enabled

## Context

`graphql@>=16.10` declares `tokenCount` as `tokenCount?: number | undefined`. Our narrower `tokenCount?: number` override rejects `graphql.DocumentNode` and packages extending it, such as `@graphql-typed-document-node/core`, when exact optional property types are enabled.

This causes the regression reported in https://github.com/urql-graphql/urql/issues/3897 after `@urql/core` started consuming this package's `DocumentNode` type directly.

## Test plan

- `pnpm check`
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm build`
- Verified the original `@graphql-typed-document-node/core` assignability reproduction compiles with the widened declaration
